### PR TITLE
Docker refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 sudo: required
 
+services:
+  - docker
+addons:
+  apt:
+    packages:
+      - docker-ce
+
+
 language: python
 python:
   # We don't actually use the Travis Python (since we are on conda), but this keeps it organized.
@@ -18,7 +26,9 @@ before_install:
   - if [ ! -f $HOME/seq/GRCh37.fa ]; then
       wget --no-check-certificate -c https://s3.amazonaws.com/biodata/genomes/GRCh37-seq.tar.gz ;
       tar -xzvpf GRCh37-seq.tar.gz --directory $HOME ;
+      rm -f GRCh37-seq.tar.gz ;
       gunzip -c $HOME/seq/GRCh37.fa.gz > $HOME/seq/GRCh37.fa ;
+      rm -f $HOME/seq/GRCh37.fa.gz ;
     fi
 
   # Cloning the test data
@@ -86,6 +96,12 @@ install:
 
 script:
   - nosetests --nocapture tests/test.py
+  - docker version
+  - docker build -t umccr/umccrise:latest -f Dockerfile .
+  - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USER" --password-stdin
+  - docker push umccr/umccrise:latest
+  - docker build -t umccr/umccrise:withdata -f Dockerfile.withdata .
+  - docker push umccr/umccrise:withdata
 
 #notifications:
 #  on_success: always

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 FROM ubuntu:16.04
 MAINTAINER Vlad Saveliev "https://github.com/vladsaveliev"
 
+ENV HOSTNAME umccrise_docker
+ENV TEST_DATA_PATH=/umccrise/tests/umccrise_test_data
+
+VOLUME $TEST_DATA_PATH
+
 # Setup a base system
 RUN apt-get update && \
     apt-get install -y curl wget git unzip tar gzip bzip2 g++ make zlib1g-dev nano
 
 # Install conda
-RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh && \
+RUN wget -nv https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh && \
     bash miniconda.sh -b -p /miniconda
 
 # Instead of `. /miniconda/etc/profile.d/conda.sh`
@@ -33,15 +38,6 @@ ENV PATH /miniconda/envs/umccrise/bin:$PATH
 ENV CONDA_PREFIX /miniconda/envs/umccrise
 ENV CONDA_DEFAULT_ENV umccrise
 
-# Download the reference data
-RUN wget --no-check-certificate -c https://s3.amazonaws.com/biodata/genomes/GRCh37-seq.tar.gz && \
-    tar -xzvpf GRCh37-seq.tar.gz --directory / && \
-    gunzip -c /seq/GRCh37.fa.gz > /seq/GRCh37.fa
-
-# Clone the test data
-RUN git clone https://github.com/umccr/umccrise_test_data umccrise/tests/umccrise_test_data && \
-    ln -s /seq umccrise/tests/umccrise_test_data/data/genomes/Hsapiens/GRCh37/seq
-
 RUN conda info -a
 
 # Copy and install source
@@ -50,9 +46,9 @@ RUN pip install -e umccrise
 
 # Clean up
 RUN rm -rf umccrise/.git && \
-    rm -rf /var/lib/apt/lists/* /var/tmp/* && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/tmp/* && \
     conda clean --yes --tarballs && \
-    cd /usr/local && apt-get clean && \
+    cd /usr/local && \
+    apt-get clean && \
     rm -rf /.cpanm
-
-ENV HOSTNAME umccrise_docker

--- a/Dockerfile.withdata
+++ b/Dockerfile.withdata
@@ -1,0 +1,5 @@
+FROM umccr/umccrise:latest
+MAINTAINER Vlad Saveliev "https://github.com/vladsaveliev"
+
+# Copy the test data into the container
+COPY tests/umccrise_test_data $TEST_DATA_PATH


### PR DESCRIPTION
Build docker images during travis run; Use locally downloaded ref
data for image build rather than downloading it again; Remove
compressed files after decompression; Split docker image in two,
one with and one without ref data;