### PR TITLE
Add ubuntu-ecs-agent role to umccrise-ami. 

### DIFF
--- a/deploy/docker.yml
+++ b/deploy/docker.yml
@@ -7,3 +7,4 @@
   roles:
     - geerlingguy.docker
     - brainstorm.umccrise-docker
+    - brainstorm.ubuntu-ecs-agent

--- a/deploy/roles/brainstorm.ubuntu-ecs-agent/.gitignore
+++ b/deploy/roles/brainstorm.ubuntu-ecs-agent/.gitignore
@@ -1,0 +1,6 @@
+.vagrant/
+*.retry
+tests/roles
+ansible.cfg
+*.sw?
+*.log

--- a/deploy/roles/brainstorm.ubuntu-ecs-agent/.travis.yml
+++ b/deploy/roles/brainstorm.ubuntu-ecs-agent/.travis.yml
@@ -1,0 +1,31 @@
+---
+sudo: required
+language: python
+python: "3.6"
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible>=2.2 
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+  # Install dependencies
+  - ansible-galaxy install -r requirements.yml
+
+script:
+  # Basic role syntax check
+  - ansible-playbook -i hosts --syntax-check docker.yml
+  - ansible-playbook -i hosts --connection=local --sudo -vvvv docker.yml
+
+# notifications:
+  # webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/deploy/roles/brainstorm.ubuntu-ecs-agent/LICENSE
+++ b/deploy/roles/brainstorm.ubuntu-ecs-agent/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Johan Meiring
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/deploy/roles/brainstorm.ubuntu-ecs-agent/README.md
+++ b/deploy/roles/brainstorm.ubuntu-ecs-agent/README.md
@@ -1,0 +1,44 @@
+# ubuntu-ecs-agent
+
+[![Build Status](https://travis-ci.org/johanmeiring/ansible-ubuntu-ecs-agent.svg?branch=master)](https://travis-ci.org/johanmeiring/ansible-ubuntu-ecs-agent)
+
+This Ansible role allows users thereof to install the [AWS ECS Agent](https://github.com/aws/amazon-ecs-agent) on Ubuntu-based instances typically running inside of an AWS environment.  This may be a requirement for some people who might not want to use the ECS-Optimized AMI from Amazon, or who may feel more comfortable working inside of Ubuntu-based environments exclusively.
+
+## Requirements
+
+* Ansible 2.2+
+* Tested on Ubuntu 14.04, 16.04 and 18.04
+
+## Role Variables
+
+Please consult http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html for detailed information regarding the options below.
+
+* `ubuntu_ecs_agent_loglevel`: `ECS_LOGLEVEL` (Default: info)
+* `ubuntu_ecs_agent_cluster_name`: `ECS_CLUSTER` (Default: default)
+* `ubuntu_ecs_agent_enable_iam_role`: `ECS_ENABLE_TASK_IAM_ROLE` (Default: true)
+* `ubuntu_ecs_agent_enable_task_iam_role_network_host`: `ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST` (Default: true)
+* `ubuntu_ecs_agent_reserved_ports`: `ECS_RESERVED_PORTS` (Default: "[22, 2375, 2376, 51678]")
+* `ubuntu_ecs_agent_container_stop_timeout`: `ECS_CONTAINER_STOP_TIMEOUT` (Default: 30s)
+* `ubuntu_ecs_agent_auth_type`: `ECS_ENGINE_AUTH_TYPE` (Default: "")
+* `ubuntu_ecs_agent_auth_data`: `ECS_ENGINE_AUTH_DATA` (Default: "")
+
+## Dependencies
+
+* [geerlingguy.docker](https://galaxy.ansible.com/geerlingguy/docker/)
+
+## Example Playbook
+
+```yaml
+---
+- name: test-playbook | Test ubuntu-ecs-agent role
+  hosts: all
+  become: yes
+  vars:
+    - ubuntu_ecs_agent_cluster_name: TestCluster
+  roles:
+    - ubuntu-ecs-agent
+```
+
+## License
+
+Licensed under the MIT License. See the LICENSE file for details.

--- a/deploy/roles/brainstorm.ubuntu-ecs-agent/Vagrantfile
+++ b/deploy/roles/brainstorm.ubuntu-ecs-agent/Vagrantfile
@@ -1,0 +1,40 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby ts=2 sw=2 tw=0 et :
+
+role = File.basename(File.expand_path(File.dirname(__FILE__)))
+
+ENV['ANSIBLE_ROLES_PATH'] = "../"
+
+boxes = [
+  {
+    :name => "ubuntu-1804",
+    :box => "ubuntu/bionic64",
+    :ip => '10.0.77.12',
+    :cpu => "33",
+    :ram => "256"
+  },
+]
+
+Vagrant.configure("2") do |config|
+  boxes.each do |box|
+    config.vm.define box[:name] do |vms|
+      vms.vm.box = box[:box]
+      vms.vm.box_url = box[:url]
+      vms.vm.hostname = "ansible-#{role}-#{box[:name]}"
+
+      vms.vm.provider "virtualbox" do |v|
+        v.customize ["modifyvm", :id, "--cpuexecutioncap", box[:cpu]]
+        v.customize ["modifyvm", :id, "--memory", box[:ram]]
+      end
+
+      vms.vm.network :private_network, ip: box[:ip]
+
+      vms.vm.provision :ansible do |ansible|
+        ansible.playbook = "tests/vagrant.yml"
+        ansible.galaxy_role_file = "requirements.yml"
+        ansible.verbose = "vv"
+        ansible.compatibility_mode = 2
+      end
+    end
+  end
+end

--- a/deploy/roles/brainstorm.ubuntu-ecs-agent/defaults/main.yml
+++ b/deploy/roles/brainstorm.ubuntu-ecs-agent/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+# defaults file for ubuntu-ecs-agent
+# Based on a subset of options available at http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html
+
+ubuntu_ecs_agent_loglevel: info
+ubuntu_ecs_agent_cluster_name: default
+ubuntu_ecs_agent_enable_iam_role: true
+ubuntu_ecs_agent_enable_task_iam_role_network_host: true
+ubuntu_ecs_agent_reserved_ports: "[22, 2375, 2376, 51678]"
+ubuntu_ecs_agent_container_stop_timeout: 30s
+ubuntu_ecs_agent_auth_type: ""
+ubuntu_ecs_agent_auth_data: ""

--- a/deploy/roles/brainstorm.ubuntu-ecs-agent/docker.yml
+++ b/deploy/roles/brainstorm.ubuntu-ecs-agent/docker.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - ansible-ubuntu-ecs-agent

--- a/deploy/roles/brainstorm.ubuntu-ecs-agent/hosts
+++ b/deploy/roles/brainstorm.ubuntu-ecs-agent/hosts
@@ -1,0 +1,2 @@
+[local]
+localhost

--- a/deploy/roles/brainstorm.ubuntu-ecs-agent/meta/main.yml
+++ b/deploy/roles/brainstorm.ubuntu-ecs-agent/meta/main.yml
@@ -1,0 +1,27 @@
+galaxy_info:
+  author: Johan Meiring
+  description: "Deploy AWS ECS Agent on Ubuntu"
+  license: MIT
+  min_ansible_version: 2.2
+
+  platforms:
+  - name: Ubuntu
+    versions:
+    - trusty
+    - utopic
+    - vivid
+    - wily
+    - xenial
+    - bionic
+
+  galaxy_tags:
+    - amazon
+    - aws
+    - ecs
+    - agent
+    - docker
+    - container
+    - ubuntu
+
+dependencies:
+  - { role: 'geerlingguy.docker'}

--- a/deploy/roles/brainstorm.ubuntu-ecs-agent/requirements.yml
+++ b/deploy/roles/brainstorm.ubuntu-ecs-agent/requirements.yml
@@ -1,0 +1,2 @@
+- src: geerlingguy.docker
+  version: 2.4.2

--- a/deploy/roles/brainstorm.ubuntu-ecs-agent/tasks/main.yml
+++ b/deploy/roles/brainstorm.ubuntu-ecs-agent/tasks/main.yml
@@ -1,0 +1,69 @@
+---
+# Based on the instructions at http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-install.html
+
+- name: Make sure vital python packages are installed beforehand
+  become: true
+  pip:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+      - docker-py
+
+- name: Set route_localnet
+  sysctl:
+    name: net.ipv4.conf.all.route_localnet
+    value: 1
+    sysctl_set: yes
+
+- name: Setup port forwarding from 80 to 51679 for metadata (1)
+  iptables:
+    table: nat
+    chain: PREROUTING
+    protocol: tcp
+    destination: 169.254.170.2
+    destination_port: 80
+    jump: DNAT
+    to_destination: 127.0.0.1:51679
+    #to_ports: 51679
+
+- name: Setup port forwarding from 80 to 51679 for metadata (2)
+  iptables:
+    table: nat
+    chain: OUTPUT
+    destination: 169.254.170.2
+    protocol: tcp
+    match: tcp
+    destination_port: 80
+    jump: REDIRECT
+    to_ports: 51679
+
+- name: create ecs environment file
+  template:
+    src=ecs.j2
+    dest=/etc/default/ecs
+    owner=root
+    group=root
+    mode=0644
+
+- name: Configure and run the ecs-agent container
+  docker_container:
+    name: ecs-agent
+    image: amazon/amazon-ecs-agent:latest
+    state: started
+    restart_policy: always
+    detach: true
+    network_mode: host
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/log/ecs/:/log
+      - /var/lib/ecs/data:/data
+    env_file: /etc/default/ecs
+    env:
+      ECS_LOGFILE: /log/ecs-agent.log
+      ECS_LOGLEVEL: "{{ ubuntu_ecs_agent_loglevel }}"
+      ECS_DATADIR: /data
+      ECS_CLUSTER: "{{ ubuntu_ecs_agent_cluster_name }}"
+      ECS_ENABLE_TASK_IAM_ROLE: "{{ ubuntu_ecs_agent_enable_iam_role }}"
+      ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST: "{{ ubuntu_ecs_agent_enable_task_iam_role_network_host }}"
+      ECS_RESERVED_PORTS: "{{ ubuntu_ecs_agent_reserved_ports }}"
+      ECS_CONTAINER_STOP_TIMEOUT: "{{ ubuntu_ecs_agent_container_stop_timeout }}"

--- a/deploy/roles/brainstorm.ubuntu-ecs-agent/templates/ecs.j2
+++ b/deploy/roles/brainstorm.ubuntu-ecs-agent/templates/ecs.j2
@@ -1,0 +1,2 @@
+ECS_ENGINE_AUTH_TYPE={{ ubuntu_ecs_agent_auth_type }}
+ECS_ENGINE_AUTH_DATA={{ ubuntu_ecs_agent_auth_data }}

--- a/deploy/roles/brainstorm.ubuntu-ecs-agent/tests/vagrant.yml
+++ b/deploy/roles/brainstorm.ubuntu-ecs-agent/tests/vagrant.yml
@@ -1,0 +1,6 @@
+---
+- hosts: all
+  become: yes
+
+  roles:
+    - ubuntu-ecs-agent


### PR DESCRIPTION
This agent is needed to control AWS Batch jobs on non-official AMIs like ours w/ umccrise in it.

More deploy stuff, sorry @vladsaveliev :-S

Have a look at [this](https://github.com/johanmeiring/ansible-ubuntu-ecs-agent/pull/2) for a bit more context.