### PR TITLE
pin libgd build

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -67,7 +67,6 @@ dependencies:
   - r-readr
   - r-stringr
   - r-htmlwidgets>=1.0  # dependency requirement for DT (by default, 0.9 is getting installed)
-  - circos                # for circos
-  - libgd                 # for circos
-  - perl-gd               # for circos
-  - perl>=5.26.0          # for circos
+  - circos=0.69.6         # for circos
+  - libgd=2.2.5=3         # for circos
+  - perl=5.22.0           # for circos


### PR DESCRIPTION
Due to a very recent update to the [libgd feedstock](https://github.com/conda-forge/libgd-feedstock/pull/25), the circos part of sig.Rmd errored out. Pinning it to build 3 solves that issue at least. I think travis now doesn't like a recent update in vcf_stuff (the log output is enormous). Don't merge this before fixing that issue so we can see for sure. 