### PR TITLE
Fixed dvc cache type

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,9 +1,9 @@
 version: 0.2
 run-as: root
 env:
-    variables:
-        "CONTAINER_REPO": "843407916570.dkr.ecr.ap-southeast-2.amazonaws.com"
-        "CONTAINER_NAME": "umccrise"
+  variables:
+    "CONTAINER_REPO": "843407916570.dkr.ecr.ap-southeast-2.amazonaws.com"
+    "CONTAINER_NAME": "umccrise"
 phases:
   install:
     runtime-versions:
@@ -11,12 +11,13 @@ phases:
       python: 3.7
   pre_build:
     commands:
-        - apk add --no-cache python3
-        - apk add py3-pip
-        - apk add --no-cache git
-        - pip3 install --no-cache --upgrade pip
-        - pip3 install --no-cache --upgrade awscli
-        - pip3 install --no-cache --upgrade 'dvc[s3]'
+      - df -h
+      - apk add --no-cache python3 tree
+      - apk add py3-pip
+      - apk add --no-cache git
+      - pip3 install --no-cache --upgrade pip
+      - pip3 install --no-cache --upgrade awscli
+      - pip3 install --no-cache --upgrade 'dvc[s3]'
   build:
     commands:
       # Docker-in-docker bizarre AWS stuff: https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker-custom-image.html
@@ -30,16 +31,24 @@ phases:
       - echo $CONTAINER_VERSION
       # Build and tag (-t) image
       - docker build -t $CONTAINER_REPO/$CONTAINER_NAME:$CONTAINER_VERSION .
+      - docker images
+      - docker system df
+      - df -h
   post_build:
     commands:
       # Clone test data
-      - git clone https://github.com/umccr/umccrise_test_data umccrise_test_data
+      - git clone --depth 1 https://github.com/umccr/umccrise_test_data umccrise_test_data
       - $(aws ecr get-login --no-include-email --region ap-southeast-2)
       # Pull refdata
       - git clone https://github.com/umccr/reference_data $PWD/reference_data &&
         cd $PWD/reference_data &&
+        dvc config cache.type reflink,hardlink,symlink &&
         dvc pull &&
+        dvc version &&
         cd $PWD
+      - du -sh $PWD/reference_data/genomes
+      - tree -L 1 $PWD/reference_data/genomes
+      - df -h
       # Run minimal test with downsized sample data - dragen
       - docker run -t --cpus 8
         -v=$PWD/umccrise_test_data/results/dragen_test_project_docker:/output_dir


### PR DESCRIPTION
* By default, dvc makes a copy between its internal
  cache space to workspace when dvc pull. For the build
  case, we rather just need any of link types. See
  https://dvc.org/doc/user-guide/large-dataset-optimization
* Made test data shallow clone
* Added few diagnostic steps for disk space monitor