### PR TITLE
Cancer report cleanup

### DIFF
--- a/envs/cancer_report.yml
+++ b/envs/cancer_report.yml
@@ -17,6 +17,7 @@ dependencies:
   - r-ggplot2
   - r-gpgr
   - r-htmlwidgets
+  - r-jsonlite
   - r-kableextra
   - r-purrr
   - r-readr

--- a/envs/cancer_report.yml
+++ b/envs/cancer_report.yml
@@ -16,6 +16,7 @@ dependencies:
   - r-dt
   - r-ggplot2
   - r-gpgr
+  - r-gt
   - r-htmlwidgets
   - r-jsonlite
   - r-kableextra

--- a/envs/cancer_report.yml
+++ b/envs/cancer_report.yml
@@ -20,6 +20,7 @@ dependencies:
   - r-htmlwidgets
   - r-jsonlite
   - r-kableextra
+  - r-patchwork
   - r-purrr
   - r-readr
   - r-rmarkdown

--- a/envs/cancer_report.yml
+++ b/envs/cancer_report.yml
@@ -11,6 +11,7 @@ dependencies:
   # R libraries:
   - pandoc
   - r-devtools
+  - r-details
   - r-dplyr
   - r-dt
   - r-ggplot2

--- a/umccrise/Snakefile
+++ b/umccrise/Snakefile
@@ -103,7 +103,6 @@ rule umccrise:
         rules.maf.output              if 'maf'              in stages else [],
         rules.germline.output         if 'germline'         in stages else [],
         rules.purple.output           if 'purple'           in stages else [],
-        rules.pierian.output          if 'pierian'          in stages else [],
         rules.cacao.output            if 'cacao'            in stages else [],
         rules.mosdepth.output         if 'mosdepth'         in stages else [],
         rules.samtools_stats.output   if 'samtools_stats'   in stages else [],

--- a/umccrise/Snakefile
+++ b/umccrise/Snakefile
@@ -103,6 +103,7 @@ rule umccrise:
         rules.maf.output              if 'maf'              in stages else [],
         rules.germline.output         if 'germline'         in stages else [],
         rules.purple.output           if 'purple'           in stages else [],
+        rules.pierian.output          if 'pierian'          in stages else [],
         rules.cacao.output            if 'cacao'            in stages else [],
         rules.mosdepth.output         if 'mosdepth'         in stages else [],
         rules.samtools_stats.output   if 'samtools_stats'   in stages else [],

--- a/umccrise/Snakefile
+++ b/umccrise/Snakefile
@@ -2,6 +2,7 @@
 """
 import os
 import sys
+import shutil
 from os.path import dirname
 from ngs_utils.bcbio import BcbioProject
 from ngs_utils.logger import debug
@@ -117,3 +118,7 @@ rule umccrise:
         rules.multiqc.output          if 'multiqc'          in stages else [],
     output:
         touch('all.done')
+
+onsuccess:
+    print("Workflow finished! Deleting .snakemake/metadata")
+    shutil.rmtree(".snakemake/metadata")

--- a/umccrise/__init__.py
+++ b/umccrise/__init__.py
@@ -339,7 +339,7 @@ def prep_stages(run, include_stages=None, exclude_stages=None):
     default_enabled = {
         'conpair',
         'structural',
-        'somatic', 'germline', 'maf', 'pierian',
+        'somatic', 'germline', 'maf',
         'purple',
         'mosdepth', 'goleft', 'cacao',
         'pcgr', 'cpsr',

--- a/umccrise/__init__.py
+++ b/umccrise/__init__.py
@@ -339,7 +339,7 @@ def prep_stages(run, include_stages=None, exclude_stages=None):
     default_enabled = {
         'conpair',
         'structural',
-        'somatic', 'germline', 'maf',
+        'somatic', 'germline', 'maf', 'pierian',
         'purple',
         'mosdepth', 'goleft', 'cacao',
         'pcgr', 'cpsr',

--- a/umccrise/cancer_report.smk
+++ b/umccrise/cancer_report.smk
@@ -1,3 +1,4 @@
+import shutil
 from os.path import join, abspath, dirname
 from ngs_utils.logger import warn
 from ngs_utils.reference_data import get_key_genes, get_key_genes_bed
@@ -191,7 +192,13 @@ purple_qc='{params.purple_qc}', \
 conda_list='{params.conda_list}' \
 ))" ; \
 cd {params.work_dir} ; \
+rm {output.rmd_tmp_dir}/vccc_small.jpg
+rm {output.rmd_tmp_dir}/style.css
+rm {output.rmd_tmp_dir}/_navbar.html
 """)
+
+        shutil.rmtree(f"{output.rmd_tmp_dir}/img")
+        shutil.rmtree(f"{output.rmd_tmp_dir}/misc")
 
 
 #############

--- a/umccrise/cancer_report.smk
+++ b/umccrise/cancer_report.smk
@@ -87,7 +87,7 @@ rule run_cancer_report:
                                if (batch_by_name[wc.batch].sv_vcf and 'structural' in stages) else [],
         somatic_sv_vcf       = lambda wc: '{batch}/structural/{batch}-manta.vcf.gz'
                                if (batch_by_name[wc.batch].sv_vcf and 'structural' in stages) else [],
-        purple_som_snv_vcf   = 'work/{batch}/purple/{batch}.purple.somatic.vcf.gz'
+        purple_som_snv_vcf   = 'work/{batch}/purple/{batch}.purple.somatic.vcf.gz',
         purple_som_cnv       = 'work/{batch}/purple/{batch}.purple.cnv.somatic.tsv',
         purple_som_gene_cnv  = 'work/{batch}/purple/{batch}.purple.cnv.gene.tsv',
         purple_germ_cnv      = 'work/{batch}/purple/{batch}.purple.cnv.germline.tsv',

--- a/umccrise/cancer_report.smk
+++ b/umccrise/cancer_report.smk
@@ -87,6 +87,7 @@ rule run_cancer_report:
                                if (batch_by_name[wc.batch].sv_vcf and 'structural' in stages) else [],
         somatic_sv_vcf       = lambda wc: '{batch}/structural/{batch}-manta.vcf.gz'
                                if (batch_by_name[wc.batch].sv_vcf and 'structural' in stages) else [],
+        purple_som_snv_vcf   = 'work/{batch}/purple/{batch}.purple.somatic.vcf.gz'
         purple_som_cnv       = 'work/{batch}/purple/{batch}.purple.cnv.somatic.tsv',
         purple_som_gene_cnv  = 'work/{batch}/purple/{batch}.purple.cnv.gene.tsv',
         purple_germ_cnv      = 'work/{batch}/purple/{batch}.purple.cnv.germline.tsv',
@@ -122,6 +123,7 @@ rule run_cancer_report:
         somatic_snv     = lambda wc, input: abspath(input.somatic_snv),
         somatic_sv      = lambda wc, input: abspath(input.somatic_sv) if input.somatic_sv else 'NA',
         somatic_sv_vcf  = lambda wc, input: abspath(input.somatic_sv_vcf) if input.somatic_sv_vcf else 'NA',
+        purple_som_snv_vcf = lambda wc, input: abspath(input.purple_som_snv_vcf),
         purple_som_cnv  = lambda wc, input: abspath(input.purple_som_cnv),
         purple_som_gene_cnv = lambda wc, input: abspath(input.purple_som_gene_cnv),
         purple_germ_cnv = lambda wc, input: abspath(input.purple_germ_cnv),
@@ -177,6 +179,7 @@ af_keygenes='{params.af_keygenes}', \
 somatic_snv='{params.somatic_snv}', \
 somatic_sv='{params.somatic_sv}', \
 somatic_sv_vcf='{params.somatic_sv_vcf}', \
+purple_som_snv_vcf='{params.purple_som_snv_vcf}', \
 purple_som_gene_cnv='{params.purple_som_gene_cnv}', \
 purple_som_cnv='{params.purple_som_cnv}', \
 purple_germ_cnv='{params.purple_germ_cnv}', \

--- a/umccrise/cancer_report.smk
+++ b/umccrise/cancer_report.smk
@@ -1,4 +1,4 @@
-from os.path import join, abspath
+from os.path import join, abspath, dirname
 from ngs_utils.logger import warn
 from ngs_utils.reference_data import get_key_genes, get_key_genes_bed
 from ngs_utils.file_utils import safe_mkdir
@@ -116,7 +116,8 @@ rule run_cancer_report:
         report_rmd = 'cancer_report.Rmd',
         tumor_name = lambda wc: batch_by_name[wc.batch].tumors[0].rgid,
         work_dir = os.getcwd(),
-        output_file = lambda wc, output: join(os.getcwd(), output[0]),
+        result_outdir   = lambda wc, output: join(os.getcwd(), dirname(output[0]), 'cancer_report_tables'),
+        output_file     = lambda wc, output: join(os.getcwd(), output[0]),
         rmd_genome_build = 'hg19' if run.genome_build in ['GRCh37', 'hg19'] else run.genome_build,
         af_global       = lambda wc, input: abspath(input.af_global),
         af_keygenes     = lambda wc, input: abspath(input.af_keygenes),
@@ -170,6 +171,7 @@ cd {output.rmd_tmp_dir} && \
 Rscript -e "rmarkdown::render('{params.report_rmd}', \
 output_file='{params.output_file}', \
 params=list( \
+result_outdir='{params.result_outdir}', \
 tumor_name='{params.tumor_name}', \
 batch_name='{wildcards.batch}', \
 genome_build='{params.rmd_genome_build}', \

--- a/umccrise/cancer_report.smk
+++ b/umccrise/cancer_report.smk
@@ -87,8 +87,9 @@ rule run_cancer_report:
                                if (batch_by_name[wc.batch].sv_vcf and 'structural' in stages) else [],
         somatic_sv_vcf       = lambda wc: '{batch}/structural/{batch}-manta.vcf.gz'
                                if (batch_by_name[wc.batch].sv_vcf and 'structural' in stages) else [],
-        purple_cnv           = 'work/{batch}/purple/{batch}.purple.cnv.somatic.tsv',
-        purple_gene_cnv      = 'work/{batch}/purple/{batch}.purple.cnv.gene.tsv',
+        purple_som_cnv       = 'work/{batch}/purple/{batch}.purple.cnv.somatic.tsv',
+        purple_som_gene_cnv  = 'work/{batch}/purple/{batch}.purple.cnv.gene.tsv',
+        purple_germ_cnv      = 'work/{batch}/purple/{batch}.purple.cnv.germline.tsv',
         purple_purity        = 'work/{batch}/purple/{batch}.purple.purity.tsv',
         purple_qc            = 'work/{batch}/purple/{batch}.purple.qc',
 
@@ -121,8 +122,9 @@ rule run_cancer_report:
         somatic_snv     = lambda wc, input: abspath(input.somatic_snv),
         somatic_sv      = lambda wc, input: abspath(input.somatic_sv) if input.somatic_sv else 'NA',
         somatic_sv_vcf  = lambda wc, input: abspath(input.somatic_sv_vcf) if input.somatic_sv_vcf else 'NA',
-        purple_gene_cnv = lambda wc, input: abspath(input.purple_gene_cnv),
-        purple_cnv      = lambda wc, input: abspath(input.purple_cnv),
+        purple_som_cnv  = lambda wc, input: abspath(input.purple_som_cnv),
+        purple_som_gene_cnv = lambda wc, input: abspath(input.purple_som_gene_cnv),
+        purple_germ_cnv = lambda wc, input: abspath(input.purple_germ_cnv),
         purple_purity   = lambda wc, input: abspath(input.purple_purity),
         purple_qc       = lambda wc, input: abspath(input.purple_qc),
         conda_list      = lambda wc, input: abspath(input.conda_list),
@@ -175,8 +177,9 @@ af_keygenes='{params.af_keygenes}', \
 somatic_snv='{params.somatic_snv}', \
 somatic_sv='{params.somatic_sv}', \
 somatic_sv_vcf='{params.somatic_sv_vcf}', \
-purple_gene_cnv='{params.purple_gene_cnv}', \
-purple_cnv='{params.purple_cnv}', \
+purple_som_gene_cnv='{params.purple_som_gene_cnv}', \
+purple_som_cnv='{params.purple_som_cnv}', \
+purple_germ_cnv='{params.purple_germ_cnv}', \
 purple_purity='{params.purple_purity}', \
 purple_qc='{params.purple_qc}', \
 {ov_cmdl} \

--- a/umccrise/coverage.smk
+++ b/umccrise/coverage.smk
@@ -77,7 +77,7 @@ rule goleft_plots:
         directory = '{batch}/coverage/{batch}-indexcov',
         xchr = 'X' if run.genome_build == 'GRCh37' else 'chrX'
     output:
-        '{batch}/coverage/{batch}-indexcov/index.html'
+        '{batch}/coverage/{batch}-indexcov/indexcov_png_html.tar.gz'
     resources:
         mem_mb=2000
     shell:
@@ -87,7 +87,8 @@ rule goleft_plots:
         '--sex {params.xchr} '
         '2>&1 | '
         'grep -v "indexcov: excluding chromosome" | '
-        'grep -v "no reference stats found" >&2'
+        'grep -v "no reference stats found" >&2 ;'
+        'tar -czf {params.directory}/indexcov_png_html.tar.gz {params.directory}/{{*.html,*.png}} --remove-files'
 
 
 pcgr_genome = 'grch38' if '38' in run.genome_build else 'grch37'

--- a/umccrise/purple.smk
+++ b/umccrise/purple.smk
@@ -138,6 +138,7 @@ rule purple_run:
         ref_fa            = refdata.get_ref_file(run.genome_build, 'fa'),
     output:
         som_cnv       = 'work/{batch}/purple/{batch}.purple.cnv.somatic.tsv',
+        som_snv_vcf   = 'work/{batch}/purple/{batch}.purple.somatic.vcf.gz',
         germ_cnv      = 'work/{batch}/purple/{batch}.purple.cnv.germline.tsv',
         som_gene_cnv  = 'work/{batch}/purple/{batch}.purple.cnv.gene.tsv',
         purity        = 'work/{batch}/purple/{batch}.purple.purity.tsv',

--- a/umccrise/purple.smk
+++ b/umccrise/purple.smk
@@ -137,8 +137,9 @@ rule purple_run:
         somatic_vcf       = rules.purple_somatic_vcf.output,
         ref_fa            = refdata.get_ref_file(run.genome_build, 'fa'),
     output:
-        cnv           = 'work/{batch}/purple/{batch}.purple.cnv.somatic.tsv',
-        gene_cnv      = 'work/{batch}/purple/{batch}.purple.cnv.gene.tsv',
+        som_cnv       = 'work/{batch}/purple/{batch}.purple.cnv.somatic.tsv',
+        germ_cnv      = 'work/{batch}/purple/{batch}.purple.cnv.germline.tsv',
+        som_gene_cnv  = 'work/{batch}/purple/{batch}.purple.cnv.gene.tsv',
         purity        = 'work/{batch}/purple/{batch}.purple.purity.tsv',
         qc            = 'work/{batch}/purple/{batch}.purple.qc',
 

--- a/umccrise/purple.smk
+++ b/umccrise/purple.smk
@@ -222,8 +222,8 @@ rule purple_circos_baf:
 
 rule purple_symlink:
     input:
-        rules.purple_run.output.cnv,
-        rules.purple_run.output.gene_cnv,
+        rules.purple_run.output.som_cnv,
+        rules.purple_run.output.som_gene_cnv,
         rules.purple_run.output.circos_png,
         rules.purple_circos_baf.output.png,
     output:

--- a/umccrise/purple.smk
+++ b/umccrise/purple.smk
@@ -208,7 +208,7 @@ rule purple_circos_baf:
         shell('mkdir -p {params.out_dir}')
         shell('cp {params.gaps_txt_prefix}_{params.genome_build}.txt {params.out_dir}/gaps.txt')
         out_conf = join(params.out_dir, basename(input.circos_baf_conf))
-        shell('sed s/SAMPLE/{wildcards.batch}/ {input.circos_baf_conf} > ' + out_conf)
+        shell('sed -e s/SAMPLE/{wildcards.batch}/ -e s/HG_ASSEMBLY/{params.genome_build}/ {input.circos_baf_conf} > ' + out_conf)
         shell('cp {input.baf} {params.out_dir}')
         shell('cp {input.cnv} {params.out_dir}')
         shell('cp {input.map} {params.out_dir}')

--- a/umccrise/rmd_files/_navbar.html
+++ b/umccrise/rmd_files/_navbar.html
@@ -17,9 +17,9 @@
             <li><a href="#signatures">Signatures</a></li>
             <li><a href="#contributions">Contributions</a></li>
             <li><a href="#rainfall">Rainfall</a></li>
-            <li><a href="#hrd">HRD</a></li>
           </ul>
         </li>
+        <li><a href="#hrd">HRD</a></li>
         <li><a href="#circos">Circos</a></li>
         <li class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">

--- a/umccrise/rmd_files/_navbar.html
+++ b/umccrise/rmd_files/_navbar.html
@@ -37,7 +37,6 @@
             CNVs <span class="caret"></span>
           </a>
           <ul class="dropdown-menu" role="menu">
-            <li><a href="#cnv-qc">QC</a></li>
             <li><a href="#cnv-gene">Genes</a></li>
             <li><a href="#cnv-segs">Segments</a></li>
             <li><a href="#purple-charts">Charts</a></li>

--- a/umccrise/rmd_files/cancer_report.Rmd
+++ b/umccrise/rmd_files/cancer_report.Rmd
@@ -115,6 +115,7 @@ library(dplyr)
 library(glue)
 library(ggplot2)
 library(htmltools)
+library(jsonlite)
 library(knitr)
 library(kableExtra)
 library(purrr)
@@ -129,11 +130,6 @@ library(gpgr)
 ```{r funcs}
 img_dir <- file.path("img") # created when copying purple files to tmp dir
 result_outdir <- params$result_outdir # directory to write tables to
-dir.create(result_outdir, recursive = TRUE)
-dir.create(file.path(result_outdir, "hrd"), recursive = TRUE)
-dir.create(file.path(result_outdir, "sv"), recursive = TRUE)
-dir.create(file.path(result_outdir, "purple"), recursive = TRUE)
-dir.create(file.path(result_outdir, "sigs"), recursive = TRUE)
 
 # for checking if the columns in the dt are all described
 check_cols_described <- function(cols, descr) {
@@ -160,6 +156,36 @@ sv_detail_table <- function(tab) {
     tibble::as_tibble() %>%
     dplyr::left_join(sv_col_descr, by = "Column")
 }
+
+mkdir <- function(d) {
+  if (!dir.exists(d)) {
+    dir.create(d, recursive = TRUE)
+  }
+}
+
+write_tsvgz <- function(x, path, ...) {
+  assertthat::assert_that(endsWith(path, ".gz"))
+  tsv_path <- file.path(result_outdir, path)
+  mkdir(dirname(tsv_path))
+  readr::write_tsv(x = x, path = tsv_path, ...)
+}
+
+write_jsongz <- function(x, path, ...) {
+  assertthat::assert_that(endsWith(path, ".gz"))
+  json_path <- file.path(result_outdir, "json",  path)
+  mkdir(dirname(json_path))
+  gz <- gzfile(json_path, open = "w")
+  jsonlite::write_json(x = x, path = gz, ...)
+  close(gz)
+}
+
+write_tsvjsongz <- function(x, path, ...) {
+  json_path <- paste0(path, ".json.gz")
+  tsv_path <- paste0(path, ".tsv.gz")
+  write_tsvgz(x, tsv_path)
+  write_jsongz(x, json_path)
+}
+
 ```
 
 ```{r allele_freq_prep}
@@ -236,18 +262,18 @@ mut_mat <- MutationalPatterns::mut_matrix(vcf_list = somatic_snv, ref_genome = r
 
 ###--- OLD Sigs ---###
 # Get Sanger sigs from "http://cancer.sanger.ac.uk/cancergenome/assets/signatures_probabilities.txt"
-sig_probs <- file.path("misc/sig/v2_mar2015/signatures_probabilities.txt")
+sig_probs1 <- file.path("misc/sig/v2_mar2015/signatures_probabilities.txt")
 # better be explicit - the sig_probs file has 7 extra empty columns
-col_types <- paste0(c("ccc", paste0(rep("d", 30), collapse = ""), "ccccccc"), collapse = "")
-col_names <- c("SubstType", "Trinucleotide", "SomMutType", paste0("Sig", 1:30), paste0("foo", 1:7))
-cancer_signatures <-
-  readr::read_tsv(sig_probs, col_names = col_names, col_types = col_types, skip = 1) %>%
+ctypes <- paste0(c("ccc", paste0(rep("d", 30), collapse = ""), "ccccccc"), collapse = "")
+cnames <- c("SubstType", "Trinucleotide", "SomMutType", paste0("Sig", 1:30), paste0("foo", 1:7))
+cancer_signatures1 <-
+  readr::read_tsv(sig_probs1, col_names = cnames, col_types = ctypes, skip = 1) %>%
   dplyr::arrange(SubstType)
 
 # sanity check - need to be in same order
-stopifnot(all(cancer_signatures$SomMutType == rownames(mut_mat)))
+stopifnot(all(cancer_signatures1$SomMutType == rownames(mut_mat)))
 # select only 30 sig columns, 96 mut types
-cancer_signatures <- cancer_signatures %>%
+cancer_signatures1 <- cancer_signatures1 %>%
   dplyr::select(4:33) %>%
   as.matrix()
 
@@ -268,25 +294,25 @@ cancer_signatures2 <- cancer_signatures2 %>%
   as.matrix()
 
 # Fit mutation matrix to cancer signatures
-fit_res <- MutationalPatterns::fit_to_signatures(mut_matrix = mut_mat, signatures = cancer_signatures)
+fit_res1 <- MutationalPatterns::fit_to_signatures(mut_matrix = mut_mat, signatures = cancer_signatures1)
 fit_res2 <- MutationalPatterns::fit_to_signatures(mut_matrix = mut_mat, signatures = cancer_signatures2)
 
 # Convert to tibbles for more bullet-proof subsetting
-fit_res <- tibble::tibble(
-  sig = rownames(fit_res$contribution), # matrix rownames
-  contr = unname(fit_res$contribution[, 1])) # matrix single column -> vector
+fit_res1 <- tibble::tibble(
+  sig = rownames(fit_res1$contribution), # matrix rownames
+  contr = unname(fit_res1$contribution[, 1])) # matrix single column -> vector
 
 fit_res2 <- tibble::tibble(
   sig = rownames(fit_res2$contribution),
   contr = unname(fit_res2$contribution[, 1]))
 
 # Select signatures with some contribution
-fit_res_contr <- dplyr::filter(fit_res, contr > 0)
+fit_res_contr1 <- dplyr::filter(fit_res1, contr > 0)
 fit_res_contr2 <- dplyr::filter(fit_res2, contr > 0)
 
 # If there are no signatures, return a dummy tibble
-if (nrow(fit_res_contr) == 0) {
-  fit_res_contr <- tibble::tibble(
+if (nrow(fit_res_contr1) == 0) {
+  fit_res_contr1 <- tibble::tibble(
     sig = "NOSIGS",
     contr = 0
   )
@@ -299,8 +325,8 @@ if (nrow(fit_res_contr2) == 0) {
   )
 }
 
-mut_sig_contr <-
-  fit_res_contr %>%
+mut_sig_contr1 <-
+  fit_res_contr1 %>%
   dplyr::mutate(contr = round(contr, 0),
                 Freq = round(contr / sum(contr), 2),
                 Rank = as.integer(base::rank(-contr))) %>%
@@ -314,8 +340,8 @@ mut_sig_contr2 <-
   dplyr::select(Rank, Signature = sig, Contribution = contr, Freq) %>%
   dplyr::arrange(Rank)
 
-readr::write_tsv(mut_sig_contr, file.path(result_outdir, "sigs/mutsig1.tsv"))
-readr::write_tsv(mut_sig_contr2, file.path(result_outdir, "sigs/mutsig2.tsv"))
+write_tsvjsongz(mut_sig_contr1, "sigs/mutsig1")
+write_tsvjsongz(mut_sig_contr2, "sigs/mutsig2")
 ```
 
 ```{r sv_prep}
@@ -345,8 +371,9 @@ if (sv_path == "NA") {
     sv_col_descr <- sv$col_descr
   }
 }
-readr::write_tsv(sv_unmelted, file.path(result_outdir, "sv/01_sv_unmelted.tsv"))
-readr::write_tsv(sv_all, file.path(result_outdir, "sv/02_sv_melted.tsv"))
+
+write_tsvjsongz(sv_unmelted, "sv/01_sv_unmelted")
+write_tsvjsongz(sv_all, "sv/02_sv_melted")
 ```
 
 ```{r purple_prep}
@@ -360,9 +387,10 @@ purple_qc_summary <- dplyr::bind_rows(
 purple_cnv_som <- gpgr::purple_cnv_som_process(params$purple_som_cnv)
 purple_cnv_som_gene <- gpgr::purple_cnv_som_gene_process(params$purple_som_gene_cnv, params$key_genes)
 purple_cnv_germ <- gpgr::purple_cnv_germ_process(params$purple_germ_cnv)
-readr::write_tsv(purple_cnv_som$tab, file.path(result_outdir, "purple/purple_cnv_som.tsv"))
-readr::write_tsv(purple_cnv_som_gene$tab, file.path(result_outdir, "purple/purple_cnv_som_gene.tsv"))
-readr::write_tsv(purple_cnv_germ$tab, file.path(result_outdir, "purple/purple_cnv_germ.tsv"))
+
+write_tsvjsongz(purple_cnv_som$tab, "purple/purple_cnv_som")
+write_tsvjsongz(purple_cnv_som_gene$tab, "purple/purple_cnv_som_gene")
+write_tsvjsongz(purple_cnv_germ$tab, "purple/purple_cnv_germ")
 ```
 
 ## Summary
@@ -412,7 +440,7 @@ There are several reasons PURPLE may classify a sample as failed:
 
 ```{r summary_tables}
 summarise_sigs <- function(mut_sig_contr) {
-  mut_sig_contr %>%
+  mut_sig_contr1 %>%
     head(2) %>%
     dplyr::mutate(string = paste0(Signature, " (", Contribution, " - ", Freq, ")")) %>%
     dplyr::pull(string) %>%
@@ -445,7 +473,7 @@ if (no_sv_found) {
 
 qc_summary_all <- dplyr::tribble(
   ~n, ~variable, ~value, ~details,
-  5, "Top MutSigs", glue::glue("Old: {summarise_sigs(mut_sig_contr)}",
+  5, "Top MutSigs", glue::glue("Old: {summarise_sigs(mut_sig_contr1)}",
                                 "New: {summarise_sigs(mut_sig_contr2)}", .sep = "\n"),
   glue::glue("Old: v2 COSMIC (https://cancer.sanger.ac.uk/cosmic/signatures_v2.tt)",
              "New: v3 COSMIC (https://cancer.sanger.ac.uk/cosmic/signatures)", .sep = "\n"),
@@ -461,8 +489,6 @@ qc_summary_all <- dplyr::tribble(
     purple_qc_summary
   ) %>%
   dplyr::arrange(n)
-
-readr::write_tsv(qc_summary_all, file.path(result_outdir, "qc_summary.tsv"))
 
 qc_summary_all %>%
   dplyr::mutate(
@@ -481,7 +507,6 @@ qc_summary_all %>%
         TRUE ~ "black"))) %>%
   knitr::kable(escape = FALSE) %>%
   kableExtra::kable_styling(full_width = FALSE, position = "left")
-
 ```
 
 ## Somatic Mutation Profiles
@@ -691,7 +716,7 @@ sig_table <-
                 signature = paste0("Sig", signature)) %>%
   dplyr::select(Signature = signature, Description = description, Plot)
 
-mut_sig_contr %>%
+mut_sig_contr1 %>%
   dplyr::left_join(sig_table, by = "Signature") %>%
   knitr::kable() %>%
   kableExtra::kable_styling(c("hover", "striped"), font_size = 12) %>%
@@ -824,8 +849,8 @@ hrdetect_res_tab <- tibble::tibble(col = colnames(hrdetect_res),
                                    val = unlist(hrdetect_res[1, ]))
 chord_res_tab <- tibble::tibble(col = colnames(chord_res$prediction),
                                 val = unlist(chord_res$prediction[1, ]))
-readr::write_tsv(hrdetect_res_tab, file.path(result_outdir, "hrd/hrdetect.tsv"))
-readr::write_tsv(chord_res_tab, file.path(result_outdir, "hrd/chord.tsv"))
+write_tsvjsongz(hrdetect_res_tab, "hrd/hrdetect")
+write_tsvjsongz(chord_res_tab, "hrd/chord")
 
 colnames(hrdetect_res_tab) <- c("HRDetect", "Results")
 colnames(chord_res_tab) <- c("CHORD", "Results1")
@@ -1135,12 +1160,10 @@ sv_BND_purple <- sv_all %>%
   dplyr::filter(Type %in% c("PURPLE_inf")) %>%
   dplyr::select(Tier, Start, Effect, Detail, Ploidy, CN, CNC, ID)
 
-readr::write_tsv(
+write_tsvjsongz(
   dplyr::bind_cols(sv_BND_main, sv_BND_other %>% dplyr::select(-nrow)),
-  file.path(result_outdir, "sv/03_sv_BND_main.tsv"))
-readr::write_tsv(
-  sv_BND_purple,
-  file.path(result_outdir, "sv/04_sv_BND_purpleinf.tsv"))
+  "sv/03_sv_BND_main")
+write_tsvjsongz(sv_BND_purple, "sv/04_sv_BND_purpleinf")
 
 sv_BND_maindt <- sv_BND_main %>%
   DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
@@ -1213,29 +1236,27 @@ sv_noBND_main <- sv_noBND %>%
   dplyr::select(nrow, vcfnum, TierTop, Tier, Type, Start, End, Effect,
                 Genes, Transcript, Detail, SR_alt, PR_alt, AF_PURPLE)
 
-readr::write_tsv(sv_noBND_main, file.path(result_outdir, "sv/05_sv_noBND_main.tsv"))
+write_tsvjsongz(sv_noBND_main, "sv/05_sv_noBND_main")
 
 sv_noBND_other <- sv_noBND %>%
   dplyr::select(vcfnum, Ploidy, AF_BPI, CNC, CN, SR_PR_ref, SScore) %>%
   dplyr::distinct()
 
-readr::write_tsv(sv_noBND_other, file.path(result_outdir, "sv/06_sv_noBND_other.tsv"))
+write_tsvjsongz(sv_noBND_other, "sv/06_sv_noBND_other")
 
 sv_noBND_manygenes <- sv_noBND %>%
   dplyr::filter(ngen > max_genes) %>%
   dplyr::select(nrow, vcfnum, Tier, Type, Start, End,
                 Effect, ngen, Genes = Genes_original)
 
-readr::write_tsv(sv_noBND_manygenes,
-                 file.path(result_outdir, "sv/07_sv_noBND_manygenes.tsv"))
+write_tsvjsongz(sv_noBND_manygenes, "sv/07_sv_noBND_manygenes")
 
 sv_noBND_manytx <- sv_noBND %>%
   dplyr::filter(ntrx > max_transcripts) %>%
   dplyr::select(nrow, vcfnum, Tier, Type, Start, End,
                 Effect, ntrx, Transcript = Transcript_original)
 
-readr::write_tsv(sv_noBND_manytx,
-                 file.path(result_outdir, "sv/08_sv_noBND_manytranscripts.tsv"))
+write_tsvjsongz(sv_noBND_manytx, "sv/08_sv_noBND_manytranscripts")
 
 sv_noBND_maindt <- sv_noBND_main %>%
   DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
@@ -1525,7 +1546,7 @@ conda_pkgs %>%
 
 ```{r report_inputs}
 report_inputs <- dplyr::tibble(key = names(params), value = unlist(params))
-readr::write_tsv(report_inputs, file.path(result_outdir, "report_inputs.tsv"))
+write_tsvjsongz(report_inputs, "report_inputs")
 
 report_inputs %>%
   knitr::kable(format = "html") %>%

--- a/umccrise/rmd_files/cancer_report.Rmd
+++ b/umccrise/rmd_files/cancer_report.Rmd
@@ -245,8 +245,7 @@ if (gpgr::vcf_is_empty(params$somatic_sv_vcf) |
     sv_vcf = params$somatic_sv_vcf,
     cnv_tsv = params$purple_som_cnv,
     genome = params$genome_build,
-    snvoutdir = tempdir()) %>%
-  dplyr::mutate(dplyr::across(where(is.numeric), ~ round(.x, 3)))
+    snvoutdir = tempdir())
 }
 ```
 
@@ -440,7 +439,7 @@ There are several reasons PURPLE may classify a sample as failed:
 
 ```{r summary_tables}
 summarise_sigs <- function(mut_sig_contr) {
-  mut_sig_contr1 %>%
+  mut_sig_contr %>%
     head(2) %>%
     dplyr::mutate(string = paste0(Signature, " (", Contribution, " - ", Freq, ")")) %>%
     dplyr::pull(string) %>%
@@ -559,12 +558,19 @@ The following post-processing steps occur:
 
 
 ```{r allele_freq_plot_stats, fig.width=10, fig.height=3}
-af_summary <- af_stats %>%
-  knitr::kable(format = "html", caption = "AF Summary Stats") %>%
-  kableExtra::kable_styling(full_width = FALSE, position = "left") %>%
-  kableExtra::column_spec(1, bold = TRUE)
-
-af_summary
+af_stats %>%
+  gt::gt(rowname_col = "set") %>%
+  gt::tab_header(
+    title = "AF Summary Stats"
+  ) %>%
+  gt::tab_stubhead(label = "Set") %>%
+  gt::tab_style(
+    style = list(
+      cell_text(weight = "bold")
+    ),
+    locations = cells_stub(rows = TRUE)
+  ) %>%
+  gt::tab_options(table.align = "left")
 
 ggplot2::ggplot(data = af_both, ggplot2::aes(af)) +
   ggplot2::geom_histogram(stat = 'bin', binwidth = 0.01, fill = "#008080") +
@@ -862,35 +868,10 @@ that includes HRDetect.
 
 </details>
 
-
-```{r chord_res}
-hrdetect_res_tab <- tibble::tibble(col = colnames(hrdetect_res),
-                                   val = unlist(hrdetect_res[1, ]))
-chord_res_tab <- tibble::tibble(col = colnames(chord_res$prediction),
-                                val = unlist(chord_res$prediction[1, ]))
-write_tsvjsongz(hrdetect_res_tab, "hrd/hrdetect")
-write_tsvjsongz(chord_res_tab, "hrd/chord")
-
-colnames(hrdetect_res_tab) <- c("HRDetect", "Results")
-colnames(chord_res_tab) <- c("CHORD", "Results1")
-
-cnames_final <- c("HRDetect", " ", " ", "CHORD", " ", "CHORD (cont.)", " ")
-
-dplyr::bind_cols(
-  hrdetect_res_tab,
-  tibble::tibble(x = rep("  |", 9)),
-  dplyr::bind_rows(chord_res_tab[1:8, ],
-                   tibble::tribble(
-                     ~CHORD, ~Results1,
-                     " ", " "
-                   )),
-  chord_res_tab[9:17, ] %>%  purrr::set_names(c("CHORD2", "Results2"))
-) %>%
-  dplyr::mutate(HRDetect = kableExtra::cell_spec(HRDetect, bold = TRUE),
-                CHORD = kableExtra::cell_spec(CHORD, bold = TRUE),
-                CHORD2 = kableExtra::cell_spec(CHORD2, bold = TRUE)) %>%
-  knitr::kable(escape = FALSE, caption = "HRD Results", col.names = cnames_final) %>%
-  kableExtra::kable_paper(c("hover", "striped"), full_width = FALSE, position = "left")
+```{r chord_hrdetect_res}
+hrd_results <- gpgr::hrd_summary(hrdetect_res, chord_res)
+write_tsvjsongz(hrd_results$hrd_results_tab, "hrd/chord_hrdetect")
+hrd_results$hrd_results_gt
 ```
 
 

--- a/umccrise/rmd_files/cancer_report.Rmd
+++ b/umccrise/rmd_files/cancer_report.Rmd
@@ -113,6 +113,7 @@ library(details)
 library(DT)
 library(dplyr)
 library(glue)
+library(gt)
 library(ggplot2)
 library(htmltools)
 library(jsonlite)
@@ -167,7 +168,7 @@ write_tsvgz <- function(x, path, ...) {
   assertthat::assert_that(endsWith(path, ".gz"))
   tsv_path <- file.path(result_outdir, path)
   mkdir(dirname(tsv_path))
-  readr::write_tsv(x = x, path = tsv_path, ...)
+  readr::write_tsv(x = x, file = tsv_path, ...)
 }
 
 write_jsongz <- function(x, path, ...) {
@@ -185,7 +186,6 @@ write_tsvjsongz <- function(x, path, ...) {
   write_tsvgz(x, tsv_path)
   write_jsongz(x, json_path)
 }
-
 ```
 
 ```{r allele_freq_prep}
@@ -450,10 +450,15 @@ summarise_sigs <- function(mut_sig_contr) {
 hrd_summary <- list(chord = round(chord_res[["prediction"]][, "p_hrd", drop = TRUE], 3),
                     hrdetect = round(hrdetect_res[, "Probability", drop = TRUE], 3))
 
-cnv_summary <- purple_cnv_som$tab %>%
-  dplyr::summarise(Min = round(min(CN), 2),
-                   Max = round(max(CN), 2),
-                   N = dplyr::n()) %>% unlist()
+cnv_summary <-
+  list(som = purple_cnv_som$tab, germ = purple_cnv_germ$tab) %>%
+  dplyr::bind_rows(.id = "group") %>%
+  dplyr::group_by(group) %>%
+  dplyr::summarise(
+    Min = round(min(CN), 2),
+    Max = round(max(CN), 2),
+    N = dplyr::n(), .groups = "drop_last") %>%
+  base::split(.$group)
 
 if (no_sv_found) {
   sv_summary <- tibble(unmelted = c(0), melted = c(0))
@@ -473,14 +478,17 @@ if (no_sv_found) {
 
 qc_summary_all <- dplyr::tribble(
   ~n, ~variable, ~value, ~details,
-  5, "Top MutSigs", glue::glue("Old: {summarise_sigs(mut_sig_contr1)}",
-                                "New: {summarise_sigs(mut_sig_contr2)}", .sep = "\n"),
-  glue::glue("Old: v2 COSMIC (https://cancer.sanger.ac.uk/cosmic/signatures_v2.tt)",
-             "New: v3 COSMIC (https://cancer.sanger.ac.uk/cosmic/signatures)", .sep = "\n"),
+  5, "MutSigs (Old)", glue::glue("{summarise_sigs(mut_sig_contr1)}"),
+  "v2 COSMIC (https://cancer.sanger.ac.uk/cosmic/signatures_v2.tt)",
+  5, "MutSigs (New)", glue::glue("{summarise_sigs(mut_sig_contr2)}"),
+  "v3 COSMIC (https://cancer.sanger.ac.uk/cosmic/signatures)",
   6, "HRD", glue::glue("CHORD: {hrd_summary$chord}; HRDetect: {hrd_summary$hrdetect}"), "",
-  16, "CNVs (Somatic)", glue::glue("Min: {cnv_summary['Min']}; ",
-                                   "Max: {cnv_summary['Max']}; ",
-                                   "N: {cnv_summary['N']} "), "",
+  16, "CNVs (Somatic)", glue::glue("Min: {cnv_summary[['som']]$Min}; ",
+                                   "Max: {cnv_summary[['som']]$Max}; ",
+                                   "N: {cnv_summary[['som']]$N} "), "",
+  16, "CNVs (Germline)", glue::glue("Min: {cnv_summary[['germ']]$Min}; ",
+                                   "Max: {cnv_summary[['germ']]$Max}; ",
+                                   "N: {cnv_summary[['germ']]$N} "), "",
   17, "SVs (unmelted)", paste(rev(sv_summary$unmelted), collapse = ", "), "",
   18, "SVs (melted)", paste(rev(sv_summary$melted), collapse = ", "), "",
   19, "Genome", params$genome_build, ""
@@ -488,25 +496,36 @@ qc_summary_all <- dplyr::tribble(
   dplyr::bind_rows(
     purple_qc_summary
   ) %>%
-  dplyr::arrange(n)
+  dplyr::arrange(n) %>%
+  dplyr::select(-n)
 
 qc_summary_all %>%
-  dplyr::mutate(
-    details = kableExtra::cell_spec(details),
-    variable = kableExtra::cell_spec(variable, bold = TRUE),
-    value = kableExtra::cell_spec(
-      value,
-      color = dplyr::case_when(
-        value == "PASS" ~ "green",
-        grepl("FAIL", value) ~ "red",
-        value == "FEMALE" ~ "purple",
-        value == "MALE" ~ "blue",
-        value == "MALE_KLINEFELTER" ~ "red",
-        value == "TRUE" ~ "green",
-        value == "FALSE" ~ "red",
-        TRUE ~ "black"))) %>%
-  knitr::kable(escape = FALSE) %>%
-  kableExtra::kable_styling(full_width = FALSE, position = "left")
+  gt::gt(rowname_col = "variable") %>%
+  gt::tab_style(
+    style = list(
+      cell_fill(color = "#FF4646"),
+      cell_text(weight = "bold")
+    ),
+    locations = cells_body(
+      columns = vars(value),
+      rows = grepl("FAIL", value) & variable == "QC_Status")) %>%
+  gt::tab_style(
+    style = list(
+      cell_fill(color = "#FF4646"),
+      cell_text(weight = "bold")
+    ),
+    locations = cells_body(
+      columns = vars(value),
+      rows = grepl("FALSE", value) & variable %in% c("Segment_Pass", "Gender_Pass", "DelGenes_Pass"))) %>%
+  gt::tab_style(
+    style = list(
+      cell_text(weight = "bold")
+    ),
+    locations = cells_stub(rows = TRUE)
+  ) %>%
+  gt::cols_align("left") %>%
+  gt::opt_row_striping() %>%
+  gt::tab_options(table.align = "left")
 ```
 
 ## Somatic Mutation Profiles
@@ -1520,7 +1539,7 @@ conda_pkgs <- readr::read_table2(params$conda_list,
                 env = sub("^umccrise_", "", env)) %>%
   dplyr::arrange(name) %>%
   dplyr::group_by(name, version, build, channel) %>%
-  dplyr::summarise(envs = paste(env, collapse = ", ")) %>%
+  dplyr::summarise(envs = paste(env, collapse = ", "), .groups = "drop_last") %>%
   dplyr::ungroup()
 
 

--- a/umccrise/rmd_files/cancer_report.Rmd
+++ b/umccrise/rmd_files/cancer_report.Rmd
@@ -10,7 +10,7 @@ output:
   rmdformats::material:
     highlight: kate
 params:
-  title: "Cancer Report for Sample "
+  title: "UMCCR Cancer Report"
   tumor_name: 'x'
   batch_name: 'x'
   genome_build: 'hg38' # 'hg19'
@@ -20,48 +20,30 @@ params:
   somatic_snv: 'x'
   somatic_sv: 'x'
   somatic_sv_vcf: 'x'
-  purple_gene_cnv: 'x'
-  purple_cnv: 'x'
+  purple_som_gene_cnv: 'x'
+  purple_som_cnv: 'x'
+  purple_germ_cnv: 'x'
   purple_purity: 'x'
   purple_qc: 'x'
+  purple_som_snv_vcf: 'x'
   oncoviral_present_viruses: 'x'
   oncoviral_breakpoints_tsv: 'x'
   conda_list: 'x'
-  # genome_build:     'hg38'
-  # tumor_name:       'T_SRR7890902_20pc'
-  # batch_name:       'T_SRR7890902_20pc'
-  # key_genes:        '~/rjn/extras/vlad/synced/NGS_Utils/ngs_utils/reference_data/key_genes/umccr_cancer_genes.latest.tsv'
-  # af_global:        '~/rjn/extras/vlad/synced/umccr/umccrise_test_data/results/T_SRR7890902_20pc/work/T_SRR7890902_20pc/rmd/afs/af_tumor.txt'
-  # af_keygenes:      '~/rjn/extras/vlad/synced/umccr/umccrise_test_data/results/T_SRR7890902_20pc/work/T_SRR7890902_20pc/rmd/afs/af_tumor_keygenes.txt'
-  # somatic_snv:      '~/rjn/extras/vlad/synced/umccr/umccrise_test_data/results/T_SRR7890902_20pc/work/T_SRR7890902_20pc/rmd/dragen-with_chr_prefix.vcf'
-  # somatic_sv:       '~/rjn/extras/vlad/synced/umccr/umccrise_test_data/results/T_SRR7890902_20pc/T_SRR7890902_20pc/structural/T_SRR7890902_20pc-manta.tsv'
-  # somatic_sv_vcf:       '~/rjn/extras/vlad/synced/umccr/umccrise_test_data/results/T_SRR7890902_20pc/T_SRR7890902_20pc/structural/T_SRR7890902_20pc-manta.vcf.gz'
-  # purple_gene_cnv:  '~/rjn/extras/vlad/synced/umccr/umccrise_test_data/results/T_SRR7890902_20pc/work/T_SRR7890902_20pc/purple/T_SRR7890902_20pc.purple.cnv.gene.tsv'
-  # purple_cnv:       '~/rjn/extras/vlad/synced/umccr/umccrise_test_data/results/T_SRR7890902_20pc/work/T_SRR7890902_20pc/purple/T_SRR7890902_20pc.purple.cnv.somatic.tsv'
-  # purple_purity:    '~/rjn/extras/vlad/synced/umccr/umccrise_test_data/results/T_SRR7890902_20pc/work/T_SRR7890902_20pc/purple/T_SRR7890902_20pc.purple.purity.tsv'
-  # purple_qc:        '~/rjn/extras/vlad/synced/umccr/umccrise_test_data/results/T_SRR7890902_20pc/work/T_SRR7890902_20pc/purple/T_SRR7890902_20pc.purple.qc'
-  # conda_list:       '~/rjn/extras/vlad/synced/umccr/umccrise_test_data/results/T_SRR7890902_20pc/work/T_SRR7890902_20pc/rmd/conda_pkg_list.txt'
+  result_outdir: 'x'
 description: "Analysis of tumor/normal samples at UMCCR"
-title: "`r paste(params$title, params$batch_name)`"
+title: "`r paste(params$batch_name, params$title)`"
 ---
-
-<style type="text/css">
-.main-container {
-  max-width: 1400px;
-  margin-left: auto;
-  margin-right: auto;
-}
-</style>
 
 ```{r knitr_opts, include=F}
 knitr::opts_chunk$set(collapse = TRUE, echo = FALSE,
                       warning = FALSE, message = FALSE)
 ```
 
-```{r render_report_interactively, eval=F, echo=F}
+```{r render_report_interactively, echo=F, eval=FALSE}
 batch_name <- "SEQCII_50pc__T_SRR7890936_50pc"
 # tumor_name <- strsplit(batch_name, "__")[[1]][2]
 tumor_name <- "T_SRR7890936_50pc"
+dd <- "/Users/pdiakumis/Desktop/projects/umccr/umccrise_dev/umccrise/umccrise/rmd_files"
 
 params_tmp <- list(
   gadi = list(
@@ -74,28 +56,34 @@ params_tmp <- list(
     somatic_snv='/g/data/gx8/projects/diakumis/umccrise/test_umccrise/umccrised/SEQCII_50pc__T_SRR7890936_50pc/small_variants/SEQCII_50pc__T_SRR7890936_50pc-somatic-PASS.vcf.gz',
     somatic_sv='/g/data/gx8/projects/diakumis/umccrise/test_umccrise/umccrised/SEQCII_50pc__T_SRR7890936_50pc/structural/SEQCII_50pc__T_SRR7890936_50pc-manta.tsv',
     somatic_sv_vcf='/g/data/gx8/projects/diakumis/umccrise/test_umccrise/umccrised/SEQCII_50pc__T_SRR7890936_50pc/structural/SEQCII_50pc__T_SRR7890936_50pc-manta.vcf.gz',
-    purple_gene_cnv='/g/data/gx8/projects/diakumis/umccrise/test_umccrise/umccrised/work/SEQCII_50pc__T_SRR7890936_50pc/purple/SEQCII_50pc__T_SRR7890936_50pc.purple.cnv.gene.tsv',
-    purple_cnv='/g/data/gx8/projects/diakumis/umccrise/test_umccrise/umccrised/work/SEQCII_50pc__T_SRR7890936_50pc/purple/SEQCII_50pc__T_SRR7890936_50pc.purple.cnv.somatic.tsv',
+    purple_som_gene_cnv='/g/data/gx8/projects/diakumis/umccrise/test_umccrise/umccrised/work/SEQCII_50pc__T_SRR7890936_50pc/purple/SEQCII_50pc__T_SRR7890936_50pc.purple.cnv.gene.tsv',
+    purple_som_cnv='/g/data/gx8/projects/diakumis/umccrise/test_umccrise/umccrised/work/SEQCII_50pc__T_SRR7890936_50pc/purple/SEQCII_50pc__T_SRR7890936_50pc.purple.cnv.somatic.tsv',
+    purple_germ_cnv='/g/data/gx8/projects/diakumis/umccrise/test_umccrise/umccrised/work/SEQCII_50pc__T_SRR7890936_50pc/purple/SEQCII_50pc__T_SRR7890936_50pc.purple.cnv.germline.tsv',
     purple_purity='/g/data/gx8/projects/diakumis/umccrise/test_umccrise/umccrised/work/SEQCII_50pc__T_SRR7890936_50pc/purple/SEQCII_50pc__T_SRR7890936_50pc.purple.purity.tsv',
     purple_qc='/g/data/gx8/projects/diakumis/umccrise/test_umccrise/umccrised/work/SEQCII_50pc__T_SRR7890936_50pc/purple/SEQCII_50pc__T_SRR7890936_50pc.purple.qc',
+    purple_som_snv_vcf='/g/data/gx8/projects/diakumis/umccrise/test_umccrise/umccrised/work/SEQCII_50pc__T_SRR7890936_50pc/purple/SEQCII_50pc__T_SRR7890936_50pc.purple.somatic.vcf.gz',
     oncoviral_present_viruses='/g/data/gx8/projects/diakumis/umccrise/test_umccrise/umccrised/work/SEQCII_50pc__T_SRR7890936_50pc/oncoviruses/present_viruses.txt',
     oncoviral_breakpoints_tsv='/g/data/gx8/projects/diakumis/umccrise/test_umccrise/umccrised/work/SEQCII_50pc__T_SRR7890936_50pc/oncoviruses/oncoviral_breakpoints.tsv',
-    conda_list='/g/data/gx8/projects/diakumis/umccrise/test_umccrise/umccrised/work/conda_pkg_list.txt'),
+    conda_list='/g/data/gx8/projects/diakumis/umccrise/test_umccrise/umccrised/work/conda_pkg_list.txt',
+    result_outdir='/g/data/gx8/projects/diakumis/umccrise/test_umccrise/umccrised/SEQCII_50pc__T_SRR7890936_50pc/cancer_report_results'),
   local = list(
     genome_build='hg38',
-    key_genes='data/ref/umccr_cancer_genes.latest.tsv',
-    af_global=glue::glue('data/umccrised/work/{batch_name}/cancer_report/afs/af_tumor.txt'),
-    af_keygenes=glue::glue('data/umccrised/work/{batch_name}/cancer_report/afs/af_tumor_keygenes.txt'),
-    somatic_snv=glue::glue('data/umccrised/{batch_name}/small_variants/{batch_name}-somatic-PASS.vcf.gz'),
-    somatic_sv=glue::glue('data/umccrised/{batch_name}/structural/{batch_name}-manta.tsv'),
-    somatic_sv_vcf=glue::glue('data/umccrised/{batch_name}/structural/{batch_name}-manta.vcf.gz'),
-    purple_gene_cnv=glue::glue('data/umccrised/work/{batch_name}/purple/{batch_name}.purple.cnv.gene.tsv'),
-    purple_cnv=glue::glue('data/umccrised/work/{batch_name}/purple/{batch_name}.purple.cnv.somatic.tsv'),
-    purple_purity=glue::glue('data/umccrised/work/{batch_name}/purple/{batch_name}.purple.purity.tsv'),
-    purple_qc=glue::glue('data/umccrised/work/{batch_name}/purple/{batch_name}.purple.qc'),
-    oncoviral_present_viruses='data/umccrised/work/{batch_name}/oncoviruses/present_viruses.txt',
-    oncoviral_breakpoints_tsv='data/umccrised/work/{batch_name}/oncoviruses/oncoviral_breakpoints.tsv',
-    conda_list=glue::glue('data/umccrised/work/conda_pkg_list.txt')
+    key_genes=glue::glue('{dd}/data/ref/umccr_cancer_genes.latest.tsv'),
+    af_global=glue::glue('{dd}/data/umccrised/work/{batch_name}/cancer_report/afs/af_tumor.txt'),
+    af_keygenes=glue::glue('{dd}/data/umccrised/work/{batch_name}/cancer_report/afs/af_tumor_keygenes.txt'),
+    somatic_snv=glue::glue('{dd}/data/umccrised/{batch_name}/small_variants/{batch_name}-somatic-PASS.vcf.gz'),
+    somatic_sv=glue::glue('{dd}/data/umccrised/{batch_name}/structural/{batch_name}-manta.tsv'),
+    somatic_sv_vcf=glue::glue('{dd}/data/umccrised/{batch_name}/structural/{batch_name}-manta.vcf.gz'),
+    purple_som_gene_cnv=glue::glue('{dd}/data/umccrised/work/{batch_name}/purple/{batch_name}.purple.cnv.gene.tsv'),
+    purple_som_cnv=glue::glue('{dd}/data/umccrised/work/{batch_name}/purple/{batch_name}.purple.cnv.somatic.tsv'),
+    purple_germ_cnv=glue::glue('{dd}/data/umccrised/work/{batch_name}/purple/{batch_name}.purple.cnv.germline.tsv'),
+    purple_purity=glue::glue('{dd}/data/umccrised/work/{batch_name}/purple/{batch_name}.purple.purity.tsv'),
+    purple_qc=glue::glue('{dd}/data/umccrised/work/{batch_name}/purple/{batch_name}.purple.qc'),
+    purple_som_snv_vcf=glue::glue('{dd}/data/umccrised/work/{batch_name}/purple/{batch_name}.purple.somatic.vcf.gz'),
+    oncoviral_present_viruses=glue::glue('{dd}/data/umccrised/work/{batch_name}/oncoviruses/present_viruses.txt'),
+    oncoviral_breakpoints_tsv=glue::glue('{dd}/data/umccrised/work/{batch_name}/oncoviruses/oncoviral_breakpoints.tsv'),
+    conda_list=glue::glue('{dd}/data/umccrised/work/conda_pkg_list.txt'),
+    result_outdir=glue::glue('{dd}/data/umccrised/{batch_name}/cancer_report_results')
   )
 )
 
@@ -121,6 +109,7 @@ tx_ref_genome <- paste0("TxDb.Hsapiens.UCSC.", params$genome_build, ".knownGene"
 library(tx_ref_genome, character.only = TRUE)
 # CRAN
 library(devtools)
+library(details)
 library(DT)
 library(dplyr)
 library(glue)
@@ -138,6 +127,14 @@ library(gpgr)
 ```
 
 ```{r funcs}
+img_dir <- file.path("img") # created when copying purple files to tmp dir
+result_outdir <- params$result_outdir # directory to write tables to
+dir.create(result_outdir, recursive = TRUE)
+dir.create(file.path(result_outdir, "hrd"), recursive = TRUE)
+dir.create(file.path(result_outdir, "sv"), recursive = TRUE)
+dir.create(file.path(result_outdir, "purple"), recursive = TRUE)
+dir.create(file.path(result_outdir, "sigs"), recursive = TRUE)
+
 # for checking if the columns in the dt are all described
 check_cols_described <- function(cols, descr) {
   stopifnot(is.character(cols), is.atomic(cols))
@@ -161,12 +158,7 @@ sv_detail_table <- function(tab) {
   check_cols_described(colnames(tab), sv_col_descr$Column)
   list(Column = colnames(tab)) %>%
     tibble::as_tibble() %>%
-    dplyr::left_join(sv_col_descr, by = "Column") %>%
-    dplyr::mutate(
-      Column = kableExtra::cell_spec(Column, bold = TRUE)) %>%
-    knitr::kable(escape = FALSE) %>%
-    kableExtra::kable_styling(full_width = FALSE, position = "left") %>%
-    kableExtra::scroll_box(height = "200px")
+    dplyr::left_join(sv_col_descr, by = "Column")
 }
 ```
 
@@ -202,6 +194,7 @@ af_stats <- af_both %>%
 ```
 
 ```{r hrd_prep}
+#---- Homologous Recombination Deficiency ----#
 chord_sv_df <- gpgr::chord_mantavcf2df(params$somatic_sv_vcf)
 chord_res <- gpgr::chord_run(
   vcf.snv = params$somatic_snv,
@@ -224,7 +217,7 @@ if (gpgr::vcf_is_empty(params$somatic_sv_vcf) |
     nm = params$tumor_name,
     snvindel_vcf = params$somatic_snv,
     sv_vcf = params$somatic_sv_vcf,
-    cnv_file = params$purple_cnv,
+    cnv_tsv = params$purple_som_cnv,
     genome = params$genome_build,
     snvoutdir = tempdir()) %>%
   dplyr::mutate(dplyr::across(where(is.numeric), ~ round(.x, 3)))
@@ -309,290 +302,119 @@ if (nrow(fit_res_contr2) == 0) {
 mut_sig_contr <-
   fit_res_contr %>%
   dplyr::mutate(contr = round(contr, 0),
+                Freq = round(contr / sum(contr), 2),
                 Rank = as.integer(base::rank(-contr))) %>%
-  dplyr::select(Rank, Signature = sig, Contribution = contr) %>%
+  dplyr::select(Rank, Signature = sig, Contribution = contr, Freq) %>%
   dplyr::arrange(Rank)
 mut_sig_contr2 <-
   fit_res_contr2 %>%
   dplyr::mutate(contr = round(contr, 0),
+                Freq = round(contr / sum(contr), 2),
                 Rank = as.integer(base::rank(-contr))) %>%
-  dplyr::select(Rank, Signature = sig, Contribution = contr) %>%
+  dplyr::select(Rank, Signature = sig, Contribution = contr, Freq) %>%
   dplyr::arrange(Rank)
+
+readr::write_tsv(mut_sig_contr, file.path(result_outdir, "sigs/mutsig1.tsv"))
+readr::write_tsv(mut_sig_contr2, file.path(result_outdir, "sigs/mutsig2.tsv"))
 ```
 
-```{r sv_prioritize_prep}
+```{r sv_prep}
 #---- Structural Variants ----#
-split_sv_field <- function(.data, field, is_pct = FALSE) {
-  # - separate field into two parts
-  # - mutate to pct accordingly
-  # - original field is mean of two parts
-  f_q <- rlang::enquo(field)
-  f_str <- rlang::quo_name(f_q)
-  f1_str <- str_c(f_str, '1')
-  f2_str <- str_c(f_str, '2')
-  f1_q <- sym(f1_str)
-  f2_q <- sym(f2_str)
-  .data %>%
-    tidyr::separate(!!f_q, c(f1_str, f2_str), sep = ",", fill = "right") %>%
-    dplyr::mutate(
-      !!f1_q := round(as.double(!!f1_q) * ifelse(is_pct, 100, 1), 1),
-      !!f2_q := round(as.double(!!f2_q) * ifelse(is_pct, 100, 1), 1),
-      !!f_q  := round(((!!f1_q + ifelse(is.na(!!f2_q), !!f1_q, !!f2_q)) / 2), 1)
-    )
-}
-
-count_pieces <- function(x, sep) {
-  ifelse(nchar(x) == 0, 0, stringr::str_count(x, sep) + 1)
-}
-
-effect_abbreviations <- c(
-  "3_prime_UTR_truncation" = "3UTRtrunc", "3_prime_UTR_variant" = "3UTRvar",
-  "5_prime_UTR_truncation" = "5UTRtrunc",  "5_prime_UTR_variant" = "5UTRvar",
-  "feature_fusion" = "Fus", "bidirectional_gene_fusion" = "BidFusG", "gene_fusion" = "FusG",
-  "chromosome_number_variation" = "ChromNumV", "conservative_inframe_deletion" = "ConsInframeDel",
-  "downstream_gene_variant" = "DnstreamGV", "upstream_gene_variant" = "UpstreamGV",
-  "duplication" = "Dup", "exon_loss_variant" = "ExonLossV",
-  "feature_ablation" = "DelG", "transcript_ablation" = "DelTx",
-  "frameshift_variant" = "FrameshiftV", "intergenic_region" = "IntergenReg", "intragenic_variant" = "IntragenV",
-  "intron_variant" = "IntronV",  "no_func_effect" = "NoFuncEff", "no_prio_effect" = "NoPrioEff",
-  "non_coding_transcript_variant" = "NoncodTxV",
-  "splice_acceptor_variant" = "SpliceAccV",
-  "splice_donor_variant" = "SpliceDonV", "splice_region_variant" = "SpliceRegV",
-  "start_lost" = "StartLoss", "stop_gained" = "StopGain", "stop_lost" = "StopLoss",
-  "TF_binding_site_variant" = "TFBSVar",  "TFBS_ablation" = "TFBSDel")
-effect_abbrev_nms <- names(effect_abbreviations)
-
-abbreviate_effect <- function(effects) {
-  # take string as x&y&z
-  # split by &
-  # abbreviate each piece and glue back with comma
-
-  .abbreviate_effect <- function(effect) {
-    ifelse(effect %in% effect_abbrev_nms, effect_abbreviations[effect], effect)
-  }
-
-  strsplit(effects, "&")[[1]] %>%
-    purrr::map_chr(.abbreviate_effect) %>%
-    paste(collapse = ", ")
-}
-abbreviate_effectv <- Vectorize(abbreviate_effect)
-
 sv_path <- params$somatic_sv
+sv <- NULL
 sv_unmelted <- NULL
 sv_all <- NULL
-somatic_sv_tsv <- NULL
-no_sv_found <- T
+no_sv_found <- TRUE
+sv_tsv_descr <- NULL
+sv_col_descr <- NULL
 if (sv_path == "NA") {
   sv_unmelted <- tibble(WARNING = "Structural variants were not called")
   sv_all <- tibble(WARNING = "Structural variants were not called")
 } else {
-  somatic_sv_tsv = readr::read_tsv(sv_path, col_names = TRUE, col_types = "ccciicccccicccccdciicc")
-  no_sv_found = length(readLines(con = sv_path, n = 2)) < 2  # only header in the file
+  no_sv_found <- gpgr::tsv_is_empty(sv_path)
   if (no_sv_found) {
     sv_unmelted <- tibble(WARNING = "THERE WERE 0 SVs PRIORITISED!")
     sv_all <- tibble(WARNING = "THERE WERE 0 SVs PRIORITISED!")
+    sv_tsv_descr <- tibble(Column = "THERE WERE 0 SVs PRIORITISED!")
+    sv_col_descr <- tibble(Column = "THERE WERE 0 SVs PRIORITISED!")
   } else {
-    sv_unmelted <- somatic_sv_tsv %>%
-      dplyr::select(-caller, -sample) %>%
-      split_sv_field(AF_BPI) %>%
-      split_sv_field(AF_PURPLE) %>%
-      split_sv_field(CN_PURPLE) %>%
-      split_sv_field(CN_change_PURPLE) %>%
-      dplyr::mutate(
-        AF_BPI = ifelse(is.na(AF_BPI), NA, paste0(AF_BPI, " (", AF_BPI1, ",", AF_BPI2, ")")),
-        AF_PURPLE = ifelse(is.na(AF_PURPLE), NA, paste0(AF_PURPLE, " (", AF_PURPLE1, ", ", AF_PURPLE2, ")")),
-        CN_PURPLE = ifelse(is.na(CN_PURPLE), NA, paste0(CN_PURPLE, " (", CN_PURPLE1, ", ", CN_PURPLE2, ")")),
-        CN_change_PURPLE = ifelse(is.na(CN_change_PURPLE), NA, paste0(CN_change_PURPLE, " (", CN_change_PURPLE1, ", ", CN_change_PURPLE2, ")"))
-      ) %>%
-      tidyr::separate(split_read_support, c("SR_ref", "SR_alt"), ",", convert = TRUE) %>%
-      tidyr::separate(paired_support_PR, c("PR_ref", "PR_alt"), ",", convert = TRUE) %>%
-      dplyr::mutate(
-        SR_PR_alt = paste0(SR_alt, ",", PR_alt),
-        SR_PR_ref = paste0(SR_ref, ",", PR_ref),
-        Ploidy = round(as.double(Ploidy_PURPLE), 2),
-        chrom = sub("chr", "", chrom),
-        chrom = as.factor(chrom), # for better DT filtering
-        svtype = ifelse(is.na(PURPLE_status), svtype, "PURPLE_inf"),
-        Start = ifelse(is.na(PURPLE_status), START_BPI, start),
-        nann = count_pieces(annotation, ","),
-        varnum = dplyr::row_number(),
-        varnum = sprintf(glue::glue("%0{nchar(nrow(.))}d"), varnum))
-
-    # Fix BND IDs
-    sv_unmelted_bnd1 <- sv_unmelted %>%
-      dplyr::filter(svtype == "BND") %>%
-      tidyr::separate(ID, into = c("BND_group", "BND_mate"), sep = -1, convert = TRUE, remove = FALSE) %>%
-      dplyr::group_by(BND_group) %>%
-      dplyr::mutate(
-        BND_ID = dplyr::cur_group_id(),
-        BND_ID = sprintf(glue::glue("%0{nchar(nrow(.))}d"), BND_ID),
-        BND_mate = ifelse(BND_mate == 0, "A", "B")) %>%
-      dplyr::ungroup()
-
-    match_id2mateid <- match(sv_unmelted_bnd1$ID, sv_unmelted_bnd1$MATEID)
-
-    sv_unmelted_bnd2 <- sv_unmelted_bnd1[match_id2mateid, c("chrom")] %>%
-      dplyr::rename(BND_mate_chrom = chrom)
-
-    sv_unmelted_bnd <- dplyr::bind_cols(sv_unmelted_bnd1, sv_unmelted_bnd2)
-
-    sv_unmelted_other <- sv_unmelted %>%
-      dplyr::filter(svtype != "BND")
-
-    sv_unmelted <-
-      dplyr::bind_rows(sv_unmelted_bnd,
-                       sv_unmelted_other) %>%
-      dplyr::mutate(
-        END_BPI = base::format(END_BPI, big.mark = ",", trim = TRUE),
-        End = ifelse(svtype == "BND", paste0(BND_mate_chrom, ":", END_BPI), END_BPI)) %>%
-      dplyr::select(varnum, TierTop = tier,
-                    Chr = chrom, Start, End,
-                    Type = svtype,
-                    ID, MATEID, BND_ID, BND_mate,
-                    SR_PR_alt, SR_PR_ref, Ploidy,
-                    AF_PURPLE, AF_BPI,
-                    CNC = CN_change_PURPLE, CN = CN_PURPLE,
-                    SScore = somaticscore, nann, annotation)
-
-    sv_all <- sv_unmelted %>%
-      dplyr::mutate(annotation = strsplit(annotation, ',')) %>%
-      tidyr::unnest(annotation) %>%
-      tidyr::separate(
-        annotation, c('Event', 'Effect', 'Genes', 'Transcript', 'Detail', 'Tier'),
-        sep = '\\|', convert = FALSE) %>%
-      dplyr::mutate(
-        ntrx = count_pieces(Transcript, "&"),
-        ngen = count_pieces(Genes, "&"),
-        neff = count_pieces(Effect, "&"),
-        Transcript = Transcript %>% stringr::str_replace_all('&', ', '),
-        Genes = Genes %>% stringr::str_replace_all('&', ', '),
-        Effect = abbreviate_effectv(Effect)) %>%
-      dplyr::distinct() %>%
-      dplyr::arrange(Tier, Genes, Effect)
+    sv <- gpgr::process_sv(sv_path)
+    sv_unmelted <- sv$unmelted
+    sv_all <- sv$melted
+    sv_tsv_descr <- sv$tsv_descr
+    sv_col_descr <- sv$col_descr
   }
 }
+readr::write_tsv(sv_unmelted, file.path(result_outdir, "sv/01_sv_unmelted.tsv"))
+readr::write_tsv(sv_all, file.path(result_outdir, "sv/02_sv_melted.tsv"))
 ```
 
-```{r purple_qc_prep}
-#---- PURPLE QC ----#
-# read both datasets
-qc_path <- params$purple_qc
-purity_path <- params$purple_purity
-
-purple_qc <-
-  file.path(qc_path) %>%
-  readr::read_tsv(col_names = c("key", "value"), col_types = "cc") %>%
-  dplyr::mutate(value = toupper(value))
-# turn into named vector
-purple_qc <- structure(purple_qc$value, names = purple_qc$key)
-
-purple_purity <-
-  file.path(purity_path) %>%
-  readr::read_tsv(col_types = cols(.default = col_double(),
-                                   gender = col_character(),
-                                   status = col_character(),
-                                   wholeGenomeDuplication = col_character(),
-                                   msStatus = col_character(),
-                                   tmlStatus = col_character(),
-                                   tmbStatus = col_character()
-  )) %>%
-  dplyr::mutate_if(is.numeric, round, 3) %>%
-  unlist()
-
-# sanity checks in case something changes between versions (PURPLE v2.34 as of 2019-09-29)
-nms_purple_qc <- c("QCStatus", "SegmentPass", "GenderPass", "DeletedGenesPass",
-                   "SegmentScore", "UnsupportedSegments", "Ploidy",
-                   "AmberGender", "CobaltGender", "DeletedGenes")
-
-nms_purple_purity <- c("purity", "normFactor", "score", "diploidProportion", "ploidy",
-                       "gender", "status", "polyclonalProportion", "minPurity", "maxPurity",
-                       "minPloidy", "maxPloidy", "minDiploidProportion", "maxDiploidProportion",
-                       "version", "somaticPenalty", "wholeGenomeDuplication", "msIndelsPerMb", "msStatus",
-                       "tml", "tmlStatus", "tmbPerMb", "tmbStatus")
-
-
-# for shorter reference in glue
-p <- purple_purity
-q <- purple_qc
-purple_qc_summary <- dplyr::tribble(
-  ~Variable        , ~value,                                                   ~details,
-  'QC_Status'      , glue('{q["QCStatus"]}')                                  , "",
-  'Purity'         , glue('{p["purity"]} ({p["minPurity"]}-{p["maxPurity"]})'), "Purity of tumor in the sample (and min-max with score within 10% of best)",
-  'Ploidy'         , glue('{p["ploidy"]} ({p["minPloidy"]}-{p["maxPloidy"]})'), "Average ploidy of tumor sample after adjusting for purity (and min-max with score within 10% of best)",
-  'Gender'         , glue('{p["gender"]}')                                    , "",
-  'WGD'            , glue('{p["wholeGenomeDuplication"]}')                    , "Whole genome duplication",
-  'MSI (indels/Mb)', glue('{p["msStatus"]} ({p["msIndelsPerMb"]})')           , "MSI status (MSI, MSS or UNKNOWN if somatic variants not supplied) & MS Indels per Mb",
-  'Polyclonal Prop', glue('{p["polyclonalProportion"]}')                      , "Proportion of CN regions that are more than 0.25 from a whole copy number",
-  'Diploidy Prop'  , glue('{p["diploidProportion"]} ({p["minDiploidProportion"]}-{p["maxDiploidProportion"]})'), glue('Proportion of CN regions that have 1 (+- 0.2) minor and major allele'),
-  'Segment_Pass'   , glue('{q["SegmentPass"]}')                               , glue('Score: {q["SegmentScore"]}; Unsupported: {q["UnsupportedSegments"]}'),
-  'Gender_Pass'    , glue('{q["GenderPass"]}')                                , glue('Amber: {q["AmberGender"]}; Cobalt: {q["CobaltGender"]}'),
-  'DelGenes_Pass'  , glue('{q["DeletedGenesPass"]}')                          , glue('count: {q["DeletedGenes"]}'),
-  'TMB'            , glue('{p["tmbPerMb"]} ({p["tmbStatus"]})')               , "Tumor mutational burden per mega base (Status: 'HIGH', 'LOW' or 'UNKNOWN' if somatic variants not supplied)",
-  'TML'            , glue('{p["tml"]} ({p["tmlStatus"]})')                    , "Tumor mutational load (Status: 'HIGH', 'LOW' or 'UNKNOWN' if somatic variants not supplied)"
+```{r purple_prep}
+#---- PURPLE QC Table ----#
+purple_qc_summary <- dplyr::bind_rows(
+  gpgr::purple_qc_read(params$purple_qc)[["summary"]],
+  gpgr::purple_purity_read(params$purple_purity)[["summary"]]
 )
-```
 
-```{r purple_gene_cnv_prep}
-#---- PURPLE Gene CNV Table ----#
-key_genes <-
-  readr::read_tsv(params$key_genes, col_types = cols(oncogene = "l", tumorsuppressor = "l")) %>%
-  dplyr::select(symbol, oncogene, tumorsuppressor)
-
-oncogenes <- key_genes %>% dplyr::filter(oncogene) %>% dplyr::pull(symbol)
-tsgenes <- key_genes %>% dplyr::filter(tumorsuppressor) %>% dplyr::pull(symbol)
-
-purple_gene_cnv <- readr::read_tsv(params$purple_gene_cnv, col_types = "ciicddcdddcccdiicccd")
-
-# sanity checks in case something changes between versions (PURPLE v2.34 as of 2019-09-29)
-nms_gene_cnv <- c("chromosome", "start", "end", "gene", "minCopyNumber", "maxCopyNumber",
-                  "unused", "somaticRegions", "germlineHomDeletionRegions", "germlineHetToHomDeletionRegions",
-                  "transcriptId", "transcriptVersion", "chromosomeBand", "minRegions",
-                  "minRegionStart", "minRegionEnd", "minRegionStartSupport", "minRegionEndSupport",
-                  "minRegionMethod", "minMinorAllelePloidy")
-stopifnot(all(colnames(purple_gene_cnv) == nms_gene_cnv))
-
-purple_gene_cnv <- purple_gene_cnv %>%
-  dplyr::filter(gene %in% key_genes$symbol) %>%
-  dplyr::mutate(chromosome = as.factor(chromosome),
-                transcriptID = paste0(transcriptId, ".", transcriptVersion),
-                minRegStartEnd = paste0(minRegionStart, "-", minRegionEnd),
-                minRegSupportStartEndMethod = paste0(minRegionStartSupport, "-", minRegionEndSupport, " (", minRegionMethod, ")"),
-                germDelReg = paste0(germlineHomDeletionRegions, "/", germlineHetToHomDeletionRegions),
-                oncogene = gene %in% oncogenes,
-                tsgene = gene %in% tsgenes,
-                onco_or_ts = dplyr::case_when(
-                  oncogene & tsgene ~ "onco+ts",
-                  oncogene ~ "oncogene",
-                  tsgene ~ "tsgene",
-                  TRUE ~ "")) %>%
-  dplyr::select(gene, minCN = minCopyNumber, maxCN = maxCopyNumber,
-                chrom = chromosome, start, end,
-                chrBand = chromosomeBand, onco_or_ts, transcriptID, minMinorAllelePloidy,
-                somReg = somaticRegions, germDelReg, minReg = minRegions,
-                minRegStartEnd, minRegSupportStartEndMethod)
-```
-
-```{r purple_global_cnv_prep}
-#---- PURPLE Global CNV Table ----#
-purple_global_cnv <- file.path(params$purple_cnv) %>%
-  readr::read_tsv(col_types = "ciididdcccdddddd")
-
-nms_purple_cnv <- c("chromosome", "start", "end", "copyNumber", "bafCount", "observedBAF",
-                    "baf", "segmentStartSupport", "segmentEndSupport", "method",
-                    "depthWindowCount", "gcContent", "minStart", "maxStart", "minorAllelePloidy",
-                    "majorAllelePloidy")
-
-# sanity checks in case something changes between versions (PURPLE v2.34 as of 2019-09-29)
-stopifnot(all(names(purple_global_cnv) == nms_purple_cnv))
+#---- PURPLE CNV Tables ----#
+purple_cnv_som <- gpgr::purple_cnv_som_process(params$purple_som_cnv)
+purple_cnv_som_gene <- gpgr::purple_cnv_som_gene_process(params$purple_som_gene_cnv, params$key_genes)
+purple_cnv_germ <- gpgr::purple_cnv_germ_process(params$purple_germ_cnv)
+readr::write_tsv(purple_cnv_som$tab, file.path(result_outdir, "purple/purple_cnv_som.tsv"))
+readr::write_tsv(purple_cnv_som_gene$tab, file.path(result_outdir, "purple/purple_cnv_som_gene.tsv"))
+readr::write_tsv(purple_cnv_germ$tab, file.path(result_outdir, "purple/purple_cnv_germ.tsv"))
 ```
 
 ## Summary
+
+<details>
+<summary>Description</summary>
+
+PURPLE outputs a QC status along with a summary
+for the inferred purity and ploidy of the somatic sample.
+A failed QC status can be attributed to several factors.
+
+__QC Status__
+
+The QC Status field reflects how we have determined the purity of the sample:
+
+* `NORMAL` - PURPLE fit the purity using COBALT and AMBER output.
+* `HIGHLY_DIPLOID` - The fitted purity solution is highly diploid (> 95%)
+  with a large range of potential solutions, but somatic variants are unable to
+  help either because they were not supplied or because their implied purity was too low.
+* `SOMATIC` - Somatic variants have improved the otherwise highly diploid solution.
+* `NO_TUMOR` - PURPLE failed to find any aneuploidy and somatic variants were
+  supplied but there were fewer than 300 with observed VAF > 0.1.
+
+__QC Failure__
+
+There are several reasons PURPLE may classify a sample as failed:
+
+* `FAIL_SEGMENT`: more than 220 copy number segments __not__ supported at either end
+  by SV breakpoints. Indicates samples with extreme GC bias, with differences
+  in depth of >= 10x between high and low GC regions. GC normalisation is
+  unreliable when the corrections are so extreme so it is recommended to fail
+  the sample (concerns with miscalled deletions or amplifications or have
+  poor sensitivity in high GC regions.
+* `NO_TUMOR`: no aneuploidy found and the number of somatic SNVs found is
+  less than 1,000
+* `MIN_PURITY`: fitted purity < 20%
+* `FAIL_DELETED_GENES`: more than 280 deleted genes. This QC step was added
+  after observing that in a handful of samples with high MB scale positive GC
+  bias we sometimes systematically underestimate the copy number in high GC
+  regions. This can lead us to incorrectly infer homozygous loss of entire
+  chromosomes, particularly on chromosomes 17 and 19.
+* `FAIL_GENDER`: if the AMBER and COBALT inferred genders are inconsistent
+  then the COBALT one is used but the sample is failed.
+
+</details>
+
 
 ```{r summary_tables}
 summarise_sigs <- function(mut_sig_contr) {
   mut_sig_contr %>%
     head(2) %>%
-    dplyr::mutate(string = paste0(Signature, " (", Contribution, ")")) %>%
+    dplyr::mutate(string = paste0(Signature, " (", Contribution, " - ", Freq, ")")) %>%
     dplyr::pull(string) %>%
     paste(collapse = ", ")
 }
@@ -600,16 +422,10 @@ summarise_sigs <- function(mut_sig_contr) {
 hrd_summary <- list(chord = round(chord_res[["prediction"]][, "p_hrd", drop = TRUE], 3),
                     hrdetect = round(hrdetect_res[, "Probability", drop = TRUE], 3))
 
-af_summary <- af_stats %>%
-  knitr::kable(format = "html", caption = "AF Summary Stats") %>%
-  kableExtra::kable_styling(full_width = FALSE, position = "left") %>%
-  kableExtra::column_spec(1, bold = TRUE)
-
-cnv_summary <- purple_global_cnv %>%
-  dplyr::rename(cn = copyNumber) %>%
-  dplyr::summarise(Min = round(min(cn), 2),
-                   Max = round(max(cn), 2),
-                   N = n()) %>% unlist()
+cnv_summary <- purple_cnv_som$tab %>%
+  dplyr::summarise(Min = round(min(CN), 2),
+                   Max = round(max(CN), 2),
+                   N = dplyr::n()) %>% unlist()
 
 if (no_sv_found) {
   sv_summary <- tibble(unmelted = c(0), melted = c(0))
@@ -627,30 +443,45 @@ if (no_sv_found) {
     dplyr::select(unmelted, melted)
 }
 
-qc_summary_all <- purple_qc_summary %>%
-  dplyr::filter(Variable %in% c("QC_Status", "Gender", "Purity", "Ploidy")) %>%
-  dplyr::select(Variable, value) %>%
+qc_summary_all <- dplyr::tribble(
+  ~n, ~variable, ~value, ~details,
+  5, "Top MutSigs", glue::glue("Old: {summarise_sigs(mut_sig_contr)}",
+                                "New: {summarise_sigs(mut_sig_contr2)}", .sep = "\n"),
+  glue::glue("Old: v2 COSMIC (https://cancer.sanger.ac.uk/cosmic/signatures_v2.tt)",
+             "New: v3 COSMIC (https://cancer.sanger.ac.uk/cosmic/signatures)", .sep = "\n"),
+  6, "HRD", glue::glue("CHORD: {hrd_summary$chord}; HRDetect: {hrd_summary$hrdetect}"), "",
+  16, "CNVs (Somatic)", glue::glue("Min: {cnv_summary['Min']}; ",
+                                   "Max: {cnv_summary['Max']}; ",
+                                   "N: {cnv_summary['N']} "), "",
+  17, "SVs (unmelted)", paste(rev(sv_summary$unmelted), collapse = ", "), "",
+  18, "SVs (melted)", paste(rev(sv_summary$melted), collapse = ", "), "",
+  19, "Genome", params$genome_build, ""
+) %>%
   dplyr::bind_rows(
-    dplyr::tribble(
-      ~Variable, ~value,
-      "Top MutSigs", glue::glue("{htmltools::strong('Old:')} {summarise_sigs(mut_sig_contr)} ",
-                                "- {htmltools::strong('New:')} {summarise_sigs(mut_sig_contr2)}"),
-      "HRD", glue::glue("{htmltools::strong('CHORD:')} {hrd_summary$chord}; ",
-                        "{htmltools::strong('HRDetect:')} {hrd_summary$hrdetect}"),
-      "CNVs (Somatic)", glue::glue("{htmltools::strong('Min: ')}{cnv_summary['Min']}; ",
-                                   "{htmltools::strong('Max: ')}{cnv_summary['Max']}; ",
-                                   "{htmltools::strong('N: ')}{cnv_summary['N']} "),
-      "SVs (unmelted)", paste(rev(sv_summary$unmelted), collapse = ", "),
-      "SVs (melted)", paste(rev(sv_summary$melted), collapse = ", "),
-      "Genome", params$genome_build
-    )
+    purple_qc_summary
   ) %>%
-  dplyr::mutate(Variable = kableExtra::cell_spec(Variable, bold = TRUE)) %>%
-  knitr::kable(escape = FALSE, col.names = NULL) %>%
+  dplyr::arrange(n)
+
+readr::write_tsv(qc_summary_all, file.path(result_outdir, "qc_summary.tsv"))
+
+qc_summary_all %>%
+  dplyr::mutate(
+    details = kableExtra::cell_spec(details),
+    variable = kableExtra::cell_spec(variable, bold = TRUE),
+    value = kableExtra::cell_spec(
+      value,
+      color = dplyr::case_when(
+        value == "PASS" ~ "green",
+        grepl("FAIL", value) ~ "red",
+        value == "FEMALE" ~ "purple",
+        value == "MALE" ~ "blue",
+        value == "MALE_KLINEFELTER" ~ "red",
+        value == "TRUE" ~ "green",
+        value == "FALSE" ~ "red",
+        TRUE ~ "black"))) %>%
+  knitr::kable(escape = FALSE) %>%
   kableExtra::kable_styling(full_width = FALSE, position = "left")
 
-qc_summary_all
-af_summary
 ```
 
 ## Somatic Mutation Profiles
@@ -684,16 +515,23 @@ The following post-processing steps occur:
 
 
 ```{r allele_freq_plot_stats, fig.width=10, fig.height=3}
-ggplot(data = af_both, aes(af)) +
-  geom_histogram(stat = 'bin', binwidth = 0.01, fill = "#006400") +
-  facet_wrap(~set, scales = 'free_y', drop = FALSE) +
-  scale_x_continuous(name = "Allele Frequency",
+af_summary <- af_stats %>%
+  knitr::kable(format = "html", caption = "AF Summary Stats") %>%
+  kableExtra::kable_styling(full_width = FALSE, position = "left") %>%
+  kableExtra::column_spec(1, bold = TRUE)
+
+af_summary
+
+ggplot2::ggplot(data = af_both, ggplot2::aes(af)) +
+  ggplot2::geom_histogram(stat = 'bin', binwidth = 0.01, fill = "#008080") +
+  ggplot2::facet_wrap(~set, scales = 'free_y', drop = FALSE) +
+  ggplot2::scale_x_continuous(name = "Allele Frequency",
                      breaks = seq(0, 1, by = 0.1),
                      limits = c(0, 1), expand = c(0, 0)) +
-  theme_bw() +
-  theme(axis.text.x = element_text(angle = 45, vjust = 1, hjust = 1),
-        panel.grid.minor = element_blank()) +
-  labs(title = paste("AF count distribution"))
+  ggplot2::theme_bw() +
+  ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 45, vjust = 1, hjust = 1),
+        panel.grid.minor = ggplot2::element_blank()) +
+  ggplot2::labs(title = "AF count distribution")
 ```
 
 ### Mutational Signatures {.tabset .tabset-fade #signatures}
@@ -729,8 +567,8 @@ between `C>T` at CpG sites and other sites.
 </details>
 
 ```{r plot_mut_type_occurrences, fig.height=3}
-type_occurrences <- mut_type_occurrences(vcf_list = somatic_snv, ref_genome = ref_genome)
-plot_spectrum(type_occurrences, CT = TRUE)
+type_occurrences <- MutationalPatterns::mut_type_occurrences(vcf_list = somatic_snv, ref_genome = ref_genome)
+MutationalPatterns::plot_spectrum(type_occurrences, CT = TRUE)
 ```
 
 #### Transcriptional strand bias
@@ -753,9 +591,9 @@ than one gene on different strands.
 ```{r tran_strand_bias, fig.height=3}
 # Get known genes table from UCSC
 if (params$genome_build == 'hg19') {
-  genes_list <- genes(TxDb.Hsapiens.UCSC.hg19.knownGene)
+  genes_list <- GenomicFeatures::genes(TxDb.Hsapiens.UCSC.hg19.knownGene)
 } else {
-  genes_list <- genes(TxDb.Hsapiens.UCSC.hg38.knownGene)
+  genes_list <- GenomicFeatures::genes(TxDb.Hsapiens.UCSC.hg38.knownGene)
 }
 
 # Mutation count matrix with strand info (4*6*4=96 -> 96*2=192)
@@ -801,13 +639,13 @@ repli_file <- system.file("extdata/ReplicationDirectionRegions.bed",
 repli_strand <-
   readr::read_tsv(repli_file, col_names = TRUE, col_types = "cddcc") %>%
   dplyr::mutate_if(is.character, as.factor)
-repli_strand_granges <- GRanges(
+repli_strand_granges <- GenomicRanges::GRanges(
   seqnames = repli_strand$Chr,
-  ranges = IRanges(start = repli_strand$Start + 1,
+  ranges = IRanges::IRanges(start = repli_strand$Start + 1,
                    end = repli_strand$Stop),
   strand_info = repli_strand$Class)
 
-seqlevelsStyle(repli_strand_granges) <- seqlevelsStyle(base::get(ref_genome))
+GenomeInfoDb::seqlevelsStyle(repli_strand_granges) <- GenomeInfoDb::seqlevelsStyle(base::get(ref_genome))
 
 mut_mat_s_rep <-
   MutationalPatterns::mut_matrix_stranded(
@@ -816,9 +654,9 @@ mut_mat_s_rep <-
     ranges = repli_strand_granges,
     mode = "replication")
 # Mutation count per type and strand
-strand_counts_rep <- strand_occurrences(mut_mat_s_rep, by = "all")
+strand_counts_rep <- MutationalPatterns::strand_occurrences(mut_mat_s_rep, by = "all")
 # Poisson test for strand asymmetry significance testing
-strand_bias_rep <- strand_bias_test(strand_counts_rep)
+strand_bias_rep <- MutationalPatterns::strand_bias_test(strand_counts_rep)
 
 MutationalPatterns::plot_strand(strand_counts_rep, mode = "relative")
 MutationalPatterns::plot_strand_bias(strand_bias_rep)
@@ -856,7 +694,7 @@ sig_table <-
 mut_sig_contr %>%
   dplyr::left_join(sig_table, by = "Signature") %>%
   knitr::kable() %>%
-  kableExtra::kable_styling(font_size = 12) %>%
+  kableExtra::kable_styling(c("hover", "striped"), font_size = 12) %>%
   kableExtra::scroll_box(height = "400px")
 ```
 
@@ -876,7 +714,7 @@ mut_sig_contr2 %>%
   dplyr::left_join(sig_table2, by = "Signature") %>%
   dplyr::mutate(Signature = ifelse(Signature %in% possible_seq_artefacts, paste0(Signature, " (SA)"), Signature)) %>%
   knitr::kable() %>%
-  kableExtra::kable_styling(font_size = 12) %>%
+  kableExtra::kable_styling(c("hover", "striped"), font_size = 12) %>%
   kableExtra::scroll_box(height = "400px")
 ```
 
@@ -889,30 +727,54 @@ previous mutation, and is log10 transformed. Drop-downs from the plots indicate 
 "hotspots" of mutations.
 
 ```{r mutationalpatterns_rainfall, out.width="90%", fig.width=14}
-# When there is only 1 or lower number of variants on a chromosome, MutationalPatterns::plot_rainfall will crash with an error. So need to check if it will work beforehand.
-chromosomes = seqnames(get(ref_genome))[1:22]
+# When there is only 1 or lower number of variants on a chromosome,
+# MutationalPatterns::plot_rainfall will crash with an error. So need to check if it will work beforehand.
+chromosomes = GenomeInfoDb::seqnames(base::get(ref_genome))[1:22]
 vcf = somatic_snv[[1]]
-chr_subset = vcf[seqnames(vcf) == chromosomes[1]]
+chr_subset = vcf[GenomeInfoDb::seqnames(vcf) == chromosomes[1]]
 n = length(chr_subset)
 will_work = FALSE
 for (i in 1:length(chromosomes)) {
-  chr_subset = vcf[seqnames(vcf) == chromosomes[i]]
+  chr_subset = vcf[GenomeInfoDb::seqnames(vcf) == chromosomes[i]]
   n = length(chr_subset)
   if (n >= 2) {
     will_work = TRUE
   }
 }
 if (will_work) {
-  MutationalPatterns::plot_rainfall(somatic_snv[[1]], chromosomes = seqnames(get(ref_genome))[1:22], cex = 1.2, ylim = 1e+09)
+  MutationalPatterns::plot_rainfall(somatic_snv[[1]],
+                                    chromosomes = GenomeInfoDb::seqnames(base::get(ref_genome))[1:22],
+                                    cex = 1.2, ylim = 1e+09)
 }
 ```
 
+Somatic variants of type C>T and C>G in a TpCpN context are annotated as
+showing Kataegis (Nik Zainal et al., 2012) if there are three or more
+mutations of that type, strand and context localised within a
+region with an average inter-mutation distance of <= 1kb.
+The annotation describes the strand it was found on
+along with an ID that is shared by grouped variants.
+
+```{r purple_kataegis_table}
+gpgr::purple_kataegis(params$purple_som_snv_vcf) %>%
+  knitr::kable(escape = FALSE, caption = "Kataegis Regions.",
+               format = "html", format.args = list(big.mark = ",")) %>%
+  kableExtra::kable_paper("hover", full_width = FALSE, position = "left") %>%
+  kableExtra::scroll_box(height = "250px")
+```
+
+```{r purple_plot_somaticrainfall, out.width="90%"}
+knitr::include_graphics(file.path(img_dir, paste0(params$batch_name, '.somatic.rainfall.png')))
+```
+
+
 ## HRD (Homologous Recombination Deficiency) Detection {#hrd}
 
-### CHORD
 
 <details>
 <summary>Description</summary>
+
+__CHORD__
 
 For more details see <https://github.com/UMCUGenetics/CHORD>.
 
@@ -949,35 +811,44 @@ If this criterion is not met, `hrd_type` will be `cannot_be_determined`, and `re
 The user may of course ignore these remarks and proceed with using the raw probabilities output by CHORD
 (`p_hrd` and/or `p_BRCA1/pBRCA2`).
 
-</details>
-
-```{r chord_res}
-tibble::tibble(col = colnames(chord_res$prediction), val = unlist(chord_res$prediction[1, ])) %>%
-  DT::datatable(class = "cell-border display compact",
-                caption = "CHORD Results",
-                rownames = FALSE, extensions = c("Buttons"),
-                options = list(buttons = c('csv', 'excel'), dom = 'Brti', paging = FALSE)) %>%
-  DT::formatStyle(columns = c("col"), fontWeight = 'bold', `text-align` = 'left')
-```
-
-### HRDetect
-
-<details>
-<summary>Description</summary>
+__HRDetect__
 
 See https://github.com/Nik-Zainal-Group/signature.tools.lib for the R package
 that includes HRDetect.
 
 </details>
 
-```{r hrdetect_res}
-tibble::tibble(col = colnames(hrdetect_res), val = unlist(hrdetect_res[1, ])) %>%
-  DT::datatable(class = "cell-border display compact",
-                caption = "HRDetect Results",
-                rownames = FALSE, extensions = c("Buttons"),
-                options = list(buttons = c('csv', 'excel'), dom = 'Brti', paging = FALSE)) %>%
-  DT::formatStyle(columns = c("col"), fontWeight = 'bold', `text-align` = 'left')
+
+```{r chord_res}
+hrdetect_res_tab <- tibble::tibble(col = colnames(hrdetect_res),
+                                   val = unlist(hrdetect_res[1, ]))
+chord_res_tab <- tibble::tibble(col = colnames(chord_res$prediction),
+                                val = unlist(chord_res$prediction[1, ]))
+readr::write_tsv(hrdetect_res_tab, file.path(result_outdir, "hrd/hrdetect.tsv"))
+readr::write_tsv(chord_res_tab, file.path(result_outdir, "hrd/chord.tsv"))
+
+colnames(hrdetect_res_tab) <- c("HRDetect", "Results")
+colnames(chord_res_tab) <- c("CHORD", "Results1")
+
+cnames_final <- c("HRDetect", " ", " ", "CHORD", " ", "CHORD (cont.)", " ")
+
+dplyr::bind_cols(
+  hrdetect_res_tab,
+  tibble::tibble(x = rep("  |", 9)),
+  dplyr::bind_rows(chord_res_tab[1:8, ],
+                   tibble::tribble(
+                     ~CHORD, ~Results1,
+                     " ", " "
+                   )),
+  chord_res_tab[9:17, ] %>%  purrr::set_names(c("CHORD2", "Results2"))
+) %>%
+  dplyr::mutate(HRDetect = kableExtra::cell_spec(HRDetect, bold = TRUE),
+                CHORD = kableExtra::cell_spec(CHORD, bold = TRUE),
+                CHORD2 = kableExtra::cell_spec(CHORD2, bold = TRUE)) %>%
+  knitr::kable(escape = FALSE, caption = "HRD Results", col.names = cnames_final) %>%
+  kableExtra::kable_paper(c("hover", "striped"), full_width = FALSE, position = "left")
 ```
+
 
 ## Circos Plots {.tabset .tabset-fade #circos}
 Circos plots are generated by PURPLE.
@@ -1013,7 +884,6 @@ The first BAF plot is based on PURPLE data and configuration files.
 </details>
 
 ```{r circos_baf_plot, out.width="80%"}
-img_dir <- file.path('img') # created before when copying purple files to tmp dir
 knitr::include_graphics(file.path(img_dir, paste0(params$batch_name, '.circos_baf.png')))
 ```
 
@@ -1130,77 +1000,12 @@ __Step 4: TSV final output__
 
 
 ```{r manta_tsv_description}
-manta_tsv_col_descr <- dplyr::tribble(
-  ~Column, ~Description,
-  "caller", "Manta SV caller",
-  "sample", "Tumor sample name",
-  "chrom", "CHROM column in VCF",
-  "start", "POS column in VCF",
-  "end", "INFO/END: End position of the variant described in this record",
-  "svtype", "INFO/SVTYPE: Type of structural variant",
-  "split_read_support", "FORMAT/SR of tumor sample: Split reads for the ref and alt alleles in the order listed, for reads where P(allele|read)>0.999",
-  "paired_support_PE", "FORMAT/PE of tumor sample: ??",
-  "paired_support_PR", "FORMAT/PR of tumor sample: Spanning paired-read support for the ref and alt alleles in the order listed, for reads where P(allele|read)>0.999",
-  "AF_BPI", "INFO/BPI_AF: AF at each breakpoint (so AF_BPI1,AF_BPI2)",
-  "somaticscore", "INFO/SOMATICSCORE: Somatic variant quality score",
-  "tier", "INFO/SV_TOP_TIER (or 4 if missing): Highest priority tier for the effects of a variant entry",
-  "annotation", "INFO/SIMPLE_ANN: Simplified structural variant annotation: 'SVTYPE | EFFECT | GENE(s) | TRANSCRIPT | PRIORITY (1-4)'",
-  "AF_PURPLE", "INFO/PURPLE_AF: AF at each breakend (purity adjusted) (so AF_PURPLE1,AF_PURPLE2)",
-  "CN_PURPLE", "INFO/PURPLE_CN: CN at each breakend (purity adjusted) (so CN_PURPLE1,CN_PURPLE2)",
-  "CN_change_PURPLE", "INFO/PURPLE_CN_CHANGE: change in CN at each breakend (purity adjusted) (so CN_change_PURPLE1,CN_change_PURPLE2)",
-  "Ploidy_PURPLE", "INFO/PURPLE_PLOIDY: Ploidy of variant (purity adjusted)",
-  "PURPLE_status", "INFERRED if FILTER=INFERRED, or RECOVERED if has INFO/RECOVERED, else blank. INFERRED: Breakend inferred from copy number transition",
-  "START_BPI", "INFO/BPI_START: BPI adjusted breakend location",
-  "END_BPI", "INFO/BPI_END: BPI adjusted breakend location",
-  "ID", "ID column in VCF",
-  "MATEID", "INFO/MATEID: ID of mate breakend")
-
-if (!is.null(somatic_sv_tsv)) {
-  check_cols_described(manta_tsv_col_descr$Column, colnames(somatic_sv_tsv))
-}
-
-manta_tsv_col_descr %>%
+sv_tsv_descr %>%
   dplyr::arrange(Column) %>%
   dplyr::mutate(Column = kableExtra::cell_spec(Column, bold = TRUE)) %>%
   knitr::kable(escape = FALSE, caption = "Description of Manta TSV columns") %>%
-  kableExtra::kable_styling(full_width = FALSE, position = "left") %>%
+  kableExtra::kable_paper(c("hover", "striped"), full_width = FALSE, position = "left") %>%
   kableExtra::scroll_box(height = "250px")
-```
-
-```{r sv_table_description}
-sv_col_descr <- dplyr::tribble(
-  ~Column, ~Description,
-  "nrow", "Row number that connects variants between tables in same tab set",
-  "varnum", "Original event row number that connects variants to events",
-  "TierTop", "Top priority of the event (from 'simple_sv_annotation': 1 highest, 4 lowest)",
-  "Tier", "Priority of the specific event (from 'simple_sv_annotation': 1 highest, 4 lowest)",
-  "Chr", "Chromosome",
-  "Start", "Start position as inferred by BPI (for PURPLE-inferred SVs we use POS)",
-  "End", paste("End position. For BNDs this has been assigned to the Chr:Start of the BND's mate for convenience.",
-               "Values are inferred by BPI (PURPLE-inferred SVs don't have an End)."),
-  "ID", "ID of BND from Manta (or PURPLE for PURPLE-inferred SVs))",
-  "MATEID", "ID of BND mate from Manta",
-  "BND_ID", "ID of BND pair simplified. BNDs with the same BND_ID belong to the same translocation event",
-  "BND_mate", "'A' or 'B' depending on if it's the first or second mate in the BND pair",
-  "Genes", "Genes involved in the event. DEL/DUP/INS events involving more than 2 genes are shown in separate table.",
-  "Transcript", "Transcripts involved in the event. DEL/DUP/INS events involving more than 2 transcripts are shown in separate table.",
-  "Effect", glue::glue("SV effect (based on ",
-                       "{htmltools::a(href='http://snpeff.sourceforge.net/SnpEff_manual.html#input', 'SnpEff Effect Sequence Ontology')}",
-                       " - abbreviations are shown under {htmltools::a(href='#sv-summary', 'Details')} in the Effects table"),
-  "Detail", "Prioritisation detail (from 'simple_sv_annotation')",
-  "Ploidy", "Ploidy of variant from PURPLE (purity adjusted)",
-  "AF_PURPLE", "PURPLE AF at each breakend preceded by their average",
-  "AF_BPI", "BPI AF at each breakend preceded by their average",
-  "CN", "Copy Number at each breakend preceded by their average",
-  "CNC", "Copy Number Change at each breakend preceded by their average",
-  "SR_PR_alt", "Number of Split Reads and Paired Reads supporting the alt allele, for reads where P(allele|read)>0.999",
-  "SR_PR_ref", "Number of Split Reads and Paired Reads supporting the ref allele, for reads where P(allele|read)>0.999",
-  "Type", "Type of structural variant",
-  "SScore", "Somatic variant quality score",
-  "ntrx", "Number of transcripts for given event",
-  "ngen", "Number of genes for given event",
-  "nann", "Number of annotations for given event"
-)
 ```
 
 <p>&nbsp;</p>
@@ -1236,12 +1041,12 @@ __Prioritisation process__
 * Use PURPLE copy number caller to infer more SV calls from copy number transitions (marked as 'PURPLE Inferred')
 
 ```{r effect_abbrev_tab}
-effect_abbreviations %>%
+gpgr::EFFECT_ABBREVIATIONS %>%
   tibble::enframe(value = "abbreviation") %>%
   dplyr::arrange(abbreviation) %>%
   dplyr::mutate(name = kableExtra::cell_spec(name, bold = TRUE)) %>%
   knitr::kable(escape = FALSE) %>%
-  kableExtra::kable_styling(full_width = FALSE, position = "left") %>%
+  kableExtra::kable_paper(c("hover", "striped"), full_width = FALSE, position = "left") %>%
   kableExtra::scroll_box(height = "250px")
 ```
 
@@ -1251,446 +1056,261 @@ effect_abbreviations %>%
 
 ### Summary
 
-```{r sv_summary, results='asis'}
-if (!no_sv_found) {
-  sv_tier_vs_svtype <- function() {
-    l <- list(unmelted = sv_unmelted %>% dplyr::select(TierTop, Type),
-              melted = sv_all %>% dplyr::select(Tier, Type)) %>%
-      purrr::map(function(x) addmargins(table(x, useNA = 'ifany')))
+```{r plot_bnd_sr_pr_tot_lines, fig.width=10, fig.height=6}
+p1 <- gpgr:::plot_bnd_sr_pr_tot_lines(sv_unmelted)
+p2 <- gpgr::plot_bnd_sr_pr_tot_hist(sv_unmelted)
+p1
+p2
+```
 
-    cap_unmelt <- glue::glue("SV type by {htmltools::strong('top')} tier {htmltools::strong('before')}",
-                             "{htmltools::br()}breaking down by annotation")
-    cap_melt <- glue::glue("SV type by {htmltools::strong('individual')} tier {htmltools::strong('after')}",
+
+```{r sv_summary, results='asis', eval=!no_sv_found}
+sv_tier_vs_svtype <- function() {
+  l <- list(unmelted = sv_unmelted %>% dplyr::select(TierTop, Type),
+            melted = sv_all %>% dplyr::select(Tier, Type)) %>%
+    purrr::map(function(x) addmargins(table(x, useNA = 'ifany')))
+
+  cap_unmelt <- glue::glue("SV type by {htmltools::strong('top')} tier {htmltools::strong('before')}",
                            "{htmltools::br()}breaking down by annotation")
-    unmelted <- knitr::kable(l$unmelted, format = "html", caption = cap_unmelt, output = FALSE) %>%
-      kableExtra::kable_styling(full_width = FALSE, position = "float_right")
-    melted <- knitr::kable(l$melted, format = "html",
-                           caption = cap_melt, output = FALSE) %>%
-      kableExtra::kable_styling(full_width = FALSE, position = "float_right")
+  cap_melt <- glue::glue("SV type by {htmltools::strong('individual')} tier {htmltools::strong('after')}",
+                         "{htmltools::br()}breaking down by annotation")
+  unmelted <- knitr::kable(l$unmelted, format = "html", caption = cap_unmelt, output = FALSE) %>%
+    kableExtra::kable_paper(c("hover", "striped"), full_width = FALSE, position = "float_right")
+  melted <- knitr::kable(l$melted, format = "html",
+                         caption = cap_melt, output = FALSE) %>%
+    kableExtra::kable_paper(c("hover", "striped"), full_width = FALSE, position = "float_right")
 
-    list(unmelted = unmelted, melted = melted)
-  }
-  cat(c('<table><tr valign="top"><td>', sv_tier_vs_svtype()$unmelted, '</td>', '<td>', sv_tier_vs_svtype()$melted, '</td></tr></table>'), sep = '')
-} else {
-  cat("No SVs called.")
+  list(unmelted = unmelted, melted = melted)
 }
+cat(c(
+  '<table><tr valign="top"><td>',
+  sv_tier_vs_svtype()$unmelted,
+  '</td>', '<td>',
+  sv_tier_vs_svtype()$melted,
+  '</td></tr></table>'),
+  sep = '')
 ```
 
 ### Unmelted Variants {#sv-unmelted}
 
-```{r svtab_raw}
-if (!no_sv_found) {
-  svtab_raw <- sv_unmelted %>%
-    dplyr::select(-annotation) %>%
-    dplyr::arrange(TierTop, varnum)
+```{r svtab_raw, eval=!no_sv_found}
+svtab_raw <- sv_unmelted %>%
+  dplyr::select(-annotation) %>%
+  dplyr::arrange(TierTop, vcfnum)
 
-  svtab_rawdt <- svtab_raw %>%
-    DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
-                  class = "cell-border display compact",
-                  rownames = FALSE, extensions = c("Scroller", "Buttons", "KeyTable"),
-                  options = list(
-                    columnDefs = list(list(className = 'dt-right', targets = col_ind_js(svtab_raw, "End"))),
-                    scroller = TRUE, scrollY = 400, scrollX = TRUE, autoWidth = FALSE, keys = TRUE,
-                    buttons = c('csv'), dom = 'Blfrtip')) %>%
-    DT::formatCurrency(~ Start, currency = "", interval = 3, mark = ",", digits = 0)
-} else {
-  svtab_raw <- NULL
-  svtab_rawdt <- NULL
-}
+svtab_rawdt <- svtab_raw %>%
+  DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
+                class = "cell-border display compact",
+                rownames = FALSE, extensions = c("Scroller", "Buttons", "KeyTable"),
+                options = list(
+                  scroller = TRUE, scrollY = 400, scrollX = TRUE, autoWidth = FALSE, keys = TRUE,
+                  buttons = c('csv'), dom = 'Blfrtip'))
 ```
 
-<details>
-<summary>Description</summary>
 
-```{r}
-if (!no_sv_found) {
-  sv_detail_table(svtab_raw)
-} else {
-  cat("No SVs called.")
-}
-```
-
-</details>
-
-```{r svtab_rawdt}
-if (!no_sv_found) {
-  svtab_rawdt
-} else {
-  cat("No SVs called.")
-}
+```{r svtab_raw_details, eval=!no_sv_found}
+details::details(sv_detail_table(svtab_raw))
+svtab_rawdt
 ```
 
 ### Translocations (BNDs) {.tabset .tabset-fade #translocations}
 
-```{r svtab_BND}
-if (!no_sv_found) {
-  sv_BND <- sv_all %>%
-    dplyr::filter(Type == "BND") %>%
-    dplyr::mutate(nrow = dplyr::row_number(),
-                  nrow = sprintf(glue::glue("%0{nchar(nrow(.))}d"), nrow)) %>%
-    dplyr::select(nrow, dplyr::everything())
+```{r svtab_BND, eval=!no_sv_found}
+sv_BND <- sv_all %>%
+  dplyr::filter(Type == "BND") %>%
+  dplyr::mutate(nrow = dplyr::row_number(),
+                nrow = sprintf(glue::glue("%0{nchar(nrow(.))}d"), nrow)) %>%
+  dplyr::select(nrow, dplyr::everything())
 
-  sv_BND_main <- sv_BND %>%
-    dplyr::select(nrow, varnum, Tier, Chr, Start, End,
-                  ID, BND_ID, BND_mate,
-                  Genes, Effect, Detail, SR_PR_alt, Ploidy, AF_PURPLE)
 
-  sv_BND_other <- sv_BND %>%
-    dplyr::select(nrow, AF_BPI, CNC, CN, SR_PR_ref, SScore, ntrx, Transcript)
+sv_BND_main <- sv_BND %>%
+  dplyr::select(nrow, vcfnum, Tier, Start, End,
+                ID, BND_ID, BND_mate,
+                Genes, Effect, Detail, SR_alt, PR_alt, Ploidy, AF_PURPLE)
 
-  sv_BND_purple <- sv_all %>%
-    dplyr::filter(Type %in% c("PURPLE_inf")) %>%
-    dplyr::select(Tier, Chr, Start, Effect, Detail, Ploidy, CN, CNC, ID)
+sv_BND_other <- sv_BND %>%
+  dplyr::select(nrow, AF_BPI, CNC, CN, SR_PR_ref, SScore, ntrx, Transcript)
 
-  sv_BND_maindt <- sv_BND_main %>%
-    DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
-                  class = "cell-border display compact",
-                  rownames = FALSE, extensions = c("Scroller", "Buttons", "KeyTable"),
-                  options = list(
-                    columnDefs = list(list(className = 'dt-right', targets = col_ind_js(svtab_raw, "End"))),
-                    scroller = TRUE, scrollY = 400, scrollX = TRUE, autoWidth = FALSE, keys = TRUE,
-                    buttons = c('csv'), dom = 'Blfrtip')) %>%
-    DT::formatCurrency(~ Start, currency = "", interval = 3, mark = ",", digits = 0)
+sv_BND_purple <- sv_all %>%
+  dplyr::filter(Type %in% c("PURPLE_inf")) %>%
+  dplyr::select(Tier, Start, Effect, Detail, Ploidy, CN, CNC, ID)
 
-  sv_BND_otherdt <- sv_BND_other %>%
-    DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
-                  class = "cell-border display compact",
-                  rownames = FALSE, extensions = c("Scroller", "Buttons", "KeyTable"),
-                  options = list(
-                    scroller = TRUE, scrollY = 400, scrollX = TRUE, keys = TRUE, autoWidth = FALSE,
-                    buttons = c('csv'), dom = 'Blfrtip'))
+readr::write_tsv(
+  dplyr::bind_cols(sv_BND_main, sv_BND_other %>% dplyr::select(-nrow)),
+  file.path(result_outdir, "sv/03_sv_BND_main.tsv"))
+readr::write_tsv(
+  sv_BND_purple,
+  file.path(result_outdir, "sv/04_sv_BND_purpleinf.tsv"))
 
-  sv_BND_purpledt <- sv_BND_purple %>%
-    DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
-                  class = "cell-border display compact",
-                  rownames = FALSE, extensions = c("Scroller", "Buttons", "KeyTable"),
-                  options = list(
-                    scroller = TRUE, scrollY = 400, scrollX = TRUE, autoWidth = TRUE,
-                    buttons = c('csv'),
-                    dom = 'Blfrtip')) %>%
-    DT::formatCurrency(~ Start, currency = "", interval = 3, mark = ",", digits = 0)
-}
+sv_BND_maindt <- sv_BND_main %>%
+  DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
+                class = "cell-border display compact",
+                rownames = FALSE, extensions = c("Scroller", "Buttons", "KeyTable"),
+                options = list(
+                  scroller = TRUE, scrollY = 400, scrollX = TRUE, autoWidth = FALSE, keys = TRUE,
+                  buttons = c('csv'), dom = 'Blfrtip'))
+
+sv_BND_otherdt <- sv_BND_other %>%
+  DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
+                class = "cell-border display compact",
+                rownames = FALSE, extensions = c("Scroller", "Buttons", "KeyTable"),
+                options = list(
+                  scroller = TRUE, scrollY = 400, scrollX = TRUE, keys = TRUE, autoWidth = FALSE,
+                  buttons = c('csv'), dom = 'Blfrtip'))
+
+sv_BND_purpledt <- sv_BND_purple %>%
+  DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
+                class = "cell-border display compact",
+                rownames = FALSE, extensions = c("Scroller", "Buttons", "KeyTable"),
+                options = list(
+                  scroller = TRUE, scrollY = 400, scrollX = TRUE, autoWidth = TRUE,
+                  buttons = c('csv'),
+                  dom = 'Blfrtip'))
 ```
 
 #### Main Columns
 
-<details>
-<summary>Description</summary>
-
-```{r}
-if (!no_sv_found) {
-  sv_detail_table(sv_BND_main)
-} else {
-  cat("No SVs called.")
-}
-```
-
-</details>
-
-```{r sv_BND_maindt}
-if (!no_sv_found) {
-  sv_BND_maindt
-} else {
-  cat("No SVs called.")
-}
-
+```{r sv_BND_main, eval=!no_sv_found}
+details::details(sv_detail_table(sv_BND_main))
+sv_BND_maindt
 ```
 
 #### Other Columns
 
-<details>
-<summary>Description</summary>
-
-```{r}
-if (!no_sv_found) {
-  sv_detail_table(sv_BND_other)
-} else {
-  cat("No SVs called.")
-}
-```
-
-</details>
-
-```{r sv_BND_otherdt}
-if (!no_sv_found) {
-  sv_BND_otherdt
-} else {
-  cat("No SVs called.")
-}
+```{r sv_BND_otherdt, eval=!no_sv_found}
+details::details(sv_detail_table(sv_BND_other))
+sv_BND_otherdt
 ```
 
 #### PURPLE Inferred
 
-<details>
-<summary>Description</summary>
-
-```{r}
-if (!no_sv_found) {
-  sv_detail_table(sv_BND_purple)
-} else {
-  cat("No SVs called.")
-}
-```
-
-</details>
-
-```{r sv_BND_purpledt}
-if (!no_sv_found) {
-  sv_BND_purpledt
-} else {
-  cat("No SVs called.")
-}
+```{r sv_BND_purple, eval=!no_sv_found}
+details::details(sv_detail_table(sv_BND_purple))
+sv_BND_purpledt
 ```
 
 ### DEL/DUP/INS {.tabset .tabset-fade #deldupins}
 
-```{r svtab_noBND}
-if (!no_sv_found) {
-  sv_noBND <- sv_all %>%
-    dplyr::filter(!Type %in% c("BND", "PURPLE_inf")) %>%
-    dplyr::mutate(nrow = dplyr::row_number(),
-                  nrow = sprintf(glue::glue("%0{nchar(nrow(.))}d"), nrow),
-                  Genes_original = Genes,
-                  Transcript_original = Transcript) %>%
-    dplyr::select(-ID)
+```{r svtab_noBND, eval=!no_sv_found}
+sv_noBND <- sv_all %>%
+  dplyr::filter(!Type %in% c("BND", "PURPLE_inf")) %>%
+  dplyr::mutate(nrow = dplyr::row_number(),
+                nrow = sprintf(glue::glue("%0{nchar(nrow(.))}d"), nrow),
+                Genes_original = Genes,
+                Transcript_original = Transcript) %>%
+  dplyr::select(-ID)
 
-  max_genes <- 2
-  max_transcripts <- 2
+max_genes <- 2
+max_transcripts <- 2
 
-  sv_noBND_main <- sv_noBND %>%
-    dplyr::mutate(Genes = ifelse(ngen > max_genes,
-                                 glue::glue("Many Genes ({ngen})"),
-                                 Genes),
-                  Transcript = ifelse(ntrx > max_transcripts,
-                                      glue::glue("Many Transcripts ({ntrx})"),
-                                      Transcript)) %>%
-    dplyr::select(nrow, varnum, TierTop, Tier, Type, Chr, Start, End, Effect,
-                  Genes, Transcript, Detail, SR_PR_alt, AF_PURPLE)
+sv_noBND_main <- sv_noBND %>%
+  dplyr::mutate(Genes = ifelse(ngen > max_genes,
+                               glue::glue("Many Genes ({ngen})"),
+                               Genes),
+                Transcript = ifelse(ntrx > max_transcripts,
+                                    glue::glue("Many Transcripts ({ntrx})"),
+                                    Transcript)) %>%
+  dplyr::select(nrow, vcfnum, TierTop, Tier, Type, Start, End, Effect,
+                Genes, Transcript, Detail, SR_alt, PR_alt, AF_PURPLE)
 
-  sv_noBND_other <- sv_noBND %>%
-    dplyr::select(varnum, Ploidy, AF_BPI, CNC, CN, SR_PR_ref, SScore) %>%
-    dplyr::distinct()
+readr::write_tsv(sv_noBND_main, file.path(result_outdir, "sv/05_sv_noBND_main.tsv"))
 
-  sv_noBND_manygenes <- sv_noBND %>%
-    dplyr::filter(ngen > max_genes) %>%
-    dplyr::select(nrow, varnum, Tier, Type, Chr, Start, End,
-                  Effect, ngen, Genes = Genes_original)
+sv_noBND_other <- sv_noBND %>%
+  dplyr::select(vcfnum, Ploidy, AF_BPI, CNC, CN, SR_PR_ref, SScore) %>%
+  dplyr::distinct()
 
-  sv_noBND_manytx <- sv_noBND %>%
-    dplyr::filter(ntrx > max_transcripts) %>%
-    dplyr::select(nrow, varnum, Tier, Type, Chr, Start, End,
-                  Effect, ntrx, Transcript = Transcript_original)
+readr::write_tsv(sv_noBND_other, file.path(result_outdir, "sv/06_sv_noBND_other.tsv"))
 
-  sv_noBND_maindt <- sv_noBND_main %>%
-    DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
-                  class = "cell-border display compact",
-                  rownames = FALSE, extensions = c("Buttons"),
-                  options = list(
-                    columnDefs = list(list(className = 'dt-right', targets = col_ind_js(svtab_raw, "End"))),
-                    pageLength = 20,
-                    autoWidth = FALSE,
-                    buttons = c('csv'), dom = 'Blfrtip')) %>%
-    DT::formatCurrency(~ Start, currency = "", interval = 3, mark = ",", digits = 0)
+sv_noBND_manygenes <- sv_noBND %>%
+  dplyr::filter(ngen > max_genes) %>%
+  dplyr::select(nrow, vcfnum, Tier, Type, Start, End,
+                Effect, ngen, Genes = Genes_original)
 
-  sv_noBND_otherdt <- sv_noBND_other %>%
-    DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
-                  class = "cell-border display compact",
-                  rownames = FALSE, extensions = c("Buttons"),
-                  options = list(
-                    pageLength = 20,
-                    autoWidth = FALSE,
-                    buttons = c('csv'),
-                    dom = 'Blfrtip'))
+readr::write_tsv(sv_noBND_manygenes,
+                 file.path(result_outdir, "sv/07_sv_noBND_manygenes.tsv"))
 
-  sv_noBND_manygenesdt <- sv_noBND_manygenes %>%
-    DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
-                  class = "cell-border display compact",
-                  rownames = FALSE, extensions = c("Buttons", "KeyTable"),
-                  options = list(
-                    columnDefs = list(list(className = 'dt-right', targets = col_ind_js(svtab_raw, "End"))),
-                    pageLength = 10,
-                    autoWidth = FALSE, keys = TRUE,
-                    buttons = c('csv'),
-                    dom = 'Blfrtip')) %>%
-    DT::formatCurrency(~ Start, currency = "", interval = 3, mark = ",", digits = 0)
+sv_noBND_manytx <- sv_noBND %>%
+  dplyr::filter(ntrx > max_transcripts) %>%
+  dplyr::select(nrow, vcfnum, Tier, Type, Start, End,
+                Effect, ntrx, Transcript = Transcript_original)
 
-  sv_noBND_manytxdt <- sv_noBND_manytx %>%
-    DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
-                  class = "cell-border display compact",
-                  rownames = FALSE, extensions = c("Buttons", "KeyTable"),
-                  options = list(
-                    columnDefs = list(list(className = 'dt-right', targets = col_ind_js(svtab_raw, "End"))),
-                    pageLength = 10,
-                    autoWidth = FALSE, keys = TRUE,
-                    buttons = c('csv'),
-                    dom = 'Blfrtip')) %>%
-    DT::formatCurrency(~ Start, currency = "", interval = 3, mark = ",", digits = 0)
-}
+readr::write_tsv(sv_noBND_manytx,
+                 file.path(result_outdir, "sv/08_sv_noBND_manytranscripts.tsv"))
+
+sv_noBND_maindt <- sv_noBND_main %>%
+  DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
+                class = "cell-border display compact",
+                rownames = FALSE, extensions = c("Buttons"),
+                options = list(
+                  pageLength = 20,
+                  autoWidth = FALSE,
+                  buttons = c('csv'), dom = 'Blfrtip'))
+
+sv_noBND_otherdt <- sv_noBND_other %>%
+  DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
+                class = "cell-border display compact",
+                rownames = FALSE, extensions = c("Buttons"),
+                options = list(
+                  pageLength = 20,
+                  autoWidth = FALSE,
+                  buttons = c('csv'),
+                  dom = 'Blfrtip'))
+
+sv_noBND_manygenesdt <- sv_noBND_manygenes %>%
+  DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
+                class = "cell-border display compact",
+                rownames = FALSE, extensions = c("Buttons", "KeyTable"),
+                options = list(
+                  pageLength = 10,
+                  autoWidth = FALSE, keys = TRUE,
+                  buttons = c('csv'),
+                  dom = 'Blfrtip'))
+
+sv_noBND_manytxdt <- sv_noBND_manytx %>%
+  DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
+                class = "cell-border display compact",
+                rownames = FALSE, extensions = c("Buttons", "KeyTable"),
+                options = list(
+                  pageLength = 10,
+                  autoWidth = FALSE, keys = TRUE,
+                  buttons = c('csv'),
+                  dom = 'Blfrtip'))
 ```
 
 #### Main Columns
 
-<details>
-<summary>Description</summary>
-
-```{r}
-if (!no_sv_found) {
-  sv_detail_table(sv_noBND_main)
-} else {
-  cat("No SVs called.")
-}
-```
-
-</details>
-
-```{r sv_noBND_maindt}
-if (!no_sv_found) {
-  sv_noBND_maindt
-} else {
-  cat("No SVs called.")
-}
+```{r sv_noBND_main, eval=!no_sv_found}
+details::details(sv_detail_table(sv_noBND_main))
+sv_noBND_maindt
 ```
 
 #### Other Columns
 
-<details>
-<summary>Description</summary>
-
-```{r}
-if (!no_sv_found) {
-  sv_detail_table(sv_noBND_other)
-} else {
-  cat("No SVs called.")
-}
-```
-
-</details>
-
-```{r sv_noBND2_dt}
-if (!no_sv_found) {
-  sv_noBND_otherdt
-} else {
-  cat("No SVs called.")
-}
+```{r sv_noBND2_other, eval=!no_sv_found}
+details::details(sv_detail_table(sv_noBND_other))
+sv_noBND_otherdt
 ```
 
 #### Many Genes
 
-<details>
-<summary>Description</summary>
-
-```{r}
-if (!no_sv_found) {
-  sv_detail_table(sv_noBND_manygenes)
-} else {
-  cat("No SVs called.")
-}
-```
-
-</details>
-
-```{r sv_noBND_manygenesdt}
-if (!no_sv_found) {
-  sv_noBND_manygenesdt
-} else {
-  cat("No SVs called.")
-}
+```{r sv_noBND_manygenes, eval=!no_sv_found}
+details::details(sv_detail_table(sv_noBND_manygenes))
+sv_noBND_manygenesdt
 ```
 
 #### Many Transcripts
 
-<details>
-<summary>Description</summary>
-
-```{r}
-if (!no_sv_found) {
-  sv_detail_table(sv_noBND_manytx)
-} else {
-  cat("No SVs called.")
-}
+```{r sv_noBND_manytx, eval=!no_sv_found}
+details::details(sv_detail_table(sv_noBND_manytx))
+sv_noBND_manytxdt
 ```
 
-</details>
-
-```{r sv_noBND_manytxdt}
-if (!no_sv_found) {
-  sv_noBND_manytxdt
-} else {
-  cat("No SVs called.")
-}
-```
-
-## Copy Number Variants {#cnv-qc}
+## Copy Number Variants
 The purity and ploidy estimator
 [PURPLE](https://github.com/hartwigmedical/hmftools/tree/master/purity-ploidy-estimator)
 is used to generate a copy number profile for the somatic sample.
 
-### QC, Purity and Ploidy Summary
-
-PURPLE outputs a QC status along with a summary
-for the inferred purity and ploidy of the somatic sample.
-A failed QC status can be attributed to several factors
-(see `Description` below).
-
-<details>
-<summary>Description</summary>
-
-__QC Status__
-
-The QC Status field reflects how we have determined the purity of the sample:
-
-* `NORMAL` - PURPLE fit the purity using COBALT and AMBER output.
-* `HIGHLY_DIPLOID` - The fitted purity solution is highly diploid (> 95%)
-  with a large range of potential solutions, but somatic variants are unable to
-  help either because they were not supplied or because their implied purity was too low.
-* `SOMATIC` - Somatic variants have improved the otherwise highly diploid solution.
-* `NO_TUMOR` - PURPLE failed to find any aneuploidy and somatic variants were
-  supplied but there were fewer than 300 with observed VAF > 0.1.
-
-__QC Failure__
-
-There are several reasons PURPLE may classify a sample as failed:
-
-* `FAIL_SEGMENT`: more than 220 copy number segments __not__ supported at either end
-  by SV breakpoints. Indicates samples with extreme GC bias, with differences
-  in depth of >= 10x between high and low GC regions. GC normalisation is
-  unreliable when the corrections are so extreme so it is recommended to fail
-  the sample (concerns with miscalled deletions or amplifications or have
-  poor sensitivity in high GC regions.
-* `NO_TUMOR`: no aneuploidy found and the number of somatic SNVs found is
-  less than 1,000
-* `MIN_PURITY`: fitted purity < 20%
-* `FAIL_DELETED_GENES`: more than 280 deleted genes. This QC step was added
-  after observing that in a handful of samples with high MB scale positive GC
-  bias we sometimes systematically underestimate the copy number in high GC
-  regions. This can lead us to incorrectly infer homozygous loss of entire
-  chromosomes, particularly on chromosomes 17 and 19.
-* `FAIL_GENDER`: if the AMBER and COBALT inferred genders are inconsistent
-  then the COBALT one is used but the sample is failed.
-
-</details>
-
-<p>&nbsp;</p>
-
-```{r purple_qc_summary}
-purple_qc_summary %>%
-  dplyr::mutate(
-    Variable = kableExtra::cell_spec(Variable, bold = TRUE),
-    value = kableExtra::cell_spec(value, bold = TRUE,
-                                  color = dplyr::case_when(
-                                    value == "PASS" ~ "green",
-                                    grepl("FAIL", value) ~ "red",
-                                    value == "FEMALE" ~ "purple",
-                                    value == "MALE" ~ "blue",
-                                    value == "MALE_KLINEFELTER" ~ "red",
-                                    value == "TRUE" ~ "green",
-                                    value == "FALSE" ~ "red",
-                                    TRUE ~ "black"))) %>%
-  knitr::kable(escape = FALSE) %>%
-  kableExtra::kable_styling(full_width = FALSE, position = "left")
-```
-
-### UMCCR Gene CNV Calls {#cnv-gene}
+### UMCCR Gene Somatic CNV Calls {#cnv-gene}
 
 <details>
 <summary>Description</summary>
@@ -1699,25 +1319,11 @@ PURPLE copy number alterations in the UMCCR Cancer Gene panel (~1,200 genes) - d
 is from <https://github.com/hartwigmedical/hmftools/blob/master/purity-ploidy-estimator/README.md#gene-copy-number-file>
 
 ```{r purple_gene_cnv_description}
-dplyr::tribble(
-  ~Column, ~Description,
-  "gene", "Name of gene",
-  "minCN/maxCN", "Min/Max copy number found in gene exons",
-  "chrom/start/end", "Chromosome/start/end location of gene transcript",
-  "chrBand", "Chromosome band of the gene",
-  "onco_or_ts", "oncogene ('oncogene'), tumor suppressor ('tsgene'), or both ('onco+ts'), as reported by [Cancermine](https://github.com/jakelever/cancermine)",
-  "transcriptID", "Ensembl transcript ID (dot version)",
-  "minMinorAllelePloidy", "Minimum allele ploidy found over the gene exons - useful for identifying LOH events",
-  "somReg (somaticRegions)", "Count of somatic copy number regions this gene spans",
-  "germDelReg (germlineHomDeletionRegions / germlineHetToHomDeletionRegions)", "Number of regions spanned by this gene that are (homozygously deleted in the germline / both heterozygously deleted in the germline and homozygously deleted in the tumor)",
-  "minReg (minRegions)", "Number of somatic regions inside the gene that share the min copy number",
-  "minRegStartEnd", "Start/End base of the copy number region overlapping the gene with the minimum copy number",
-  "minRegSupportStartEndMethod", "Start/end support of the CN region overlapping the gene with the min CN (plus determination method)"
-) %>%
+purple_cnv_som_gene$descr %>%
   dplyr::mutate(
     Column = kableExtra::cell_spec(Column, bold = TRUE)) %>%
   knitr::kable(escape = FALSE) %>%
-  kableExtra::kable_styling(full_width = FALSE, position = "left") %>%
+  kableExtra::kable_paper(c("hover", "striped"), full_width = FALSE, position = "left") %>%
   kableExtra::scroll_box(height = "200px")
 ```
 
@@ -1726,7 +1332,7 @@ dplyr::tribble(
 <p>&nbsp;</p>
 
 ```{r purple_gene_cnv_tab}
-purple_gene_cnv %>%
+purple_cnv_som_gene$tab %>%
   DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
                 class = "cell-border display compact",
                 rownames = FALSE, extensions = c("Scroller", "Buttons", "KeyTable"),
@@ -1736,7 +1342,7 @@ purple_gene_cnv %>%
   DT::formatRound(~ minCN + maxCN, digits = 1)
 ```
 
-### Genome-wide CNV Segments {#cnv-segs}
+### Genome-wide Somatic CNV Segments {#cnv-segs}
 
 <details>
 <summary>Description</summary>
@@ -1749,21 +1355,11 @@ is from <https://github.com/hartwigmedical/hmftools/blob/master/purity-ploidy-es
 
 
 ```{r purple_seg_description}
-dplyr::tribble(
-  ~Column, ~Description,
-  "Chr/Start/End", "Coordinates of copy number segment",
-  "CN", "Fitted absolute copy number of segment adjusted for purity and ploidy",
-  "Ploidy Min+Maj", "Ploidy of minor + major allele adjusted for purity",
-  "BAF", "Tumor BAF after adjusted for purity and ploidy",
-  "BafCount", "Count of AMBER baf points covered by this segment",
-  "Start/End SegSupport", "Type of SV support for the CN breakpoint at start/end of region. Allowed values: CENTROMERE, TELOMERE, INV, DEL, DUP, BND (translocation), SGL (single breakend SV support), NONE (no SV support for CN breakpoint), MULT (multiple SV support at exact breakpoint)",
-  "Method", "Method used to determine the CN of the region. Allowed values: BAF_WEIGHTED (avg of all depth windows for the region), STRUCTURAL_VARIANT (inferred using ploidy of flanking SVs), LONG_ARM (inferred from the long arm), GERMLINE_AMPLIFICATION (inferred using special logic to handle regions of germline amplification)",
-  "windowCount", "Count of COBALT windows covered by this segment",
-  "GC", "Proportion of segment that is G or C") %>%
+purple_cnv_som$descr %>%
   dplyr::mutate(
     Column = kableExtra::cell_spec(Column, bold = TRUE)) %>%
   knitr::kable(escape = FALSE) %>%
-  kableExtra::kable_styling(full_width = FALSE, position = "left") %>%
+  kableExtra::kable_paper(c("hover", "striped"), full_width = FALSE, position = "left") %>%
   kableExtra::scroll_box(height = "200px")
 ```
 
@@ -1771,20 +1367,8 @@ dplyr::tribble(
 
 <p>&nbsp;</p>
 
-```{r purple_global_cnv_tab}
-purple_global_cnv %>%
-  dplyr::mutate(Chr = as.factor(`chromosome`),
-                minorAllelePloidy = round(minorAllelePloidy, 1),
-                majorAllelePloidy = round(majorAllelePloidy, 1),
-                `Ploidy Min+Maj` = paste0(minorAllelePloidy, "+", majorAllelePloidy),
-                copyNumber = round(copyNumber, 1),
-                bafAdj = round(baf, 2),
-                gcContent = round(gcContent, 2),
-                `Start/End SegSupport` = paste0(segmentStartSupport, "-", segmentEndSupport),
-                `BAF (count)` = paste0(bafAdj, " (", bafCount, ")"),
-                `GC (windowCount)` = paste0(gcContent, " (", depthWindowCount, ")")) %>%
-  dplyr::select(Chr, Start = start, End = end, CN = copyNumber, `Ploidy Min+Maj`,
-                `Start/End SegSupport`, Method = method, `BAF (count)`, `GC (windowCount)`) %>%
+```{r purple_cnv_som_tab}
+purple_cnv_som$tab %>%
   DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
                 class = "cell-border display compact",
                 rownames = FALSE, extensions = c("Scroller", "Buttons", "KeyTable"),
@@ -1792,6 +1376,19 @@ purple_global_cnv %>%
                                buttons = c('csv', 'excel'), dom = 'Bfrtip')) %>%
   DT::formatCurrency(~ Start + End, currency = "", interval = 3, mark = ",", digits = 0)
 ```
+
+### Genome-wide __Germline__ CNV Segments
+
+```{r purple_cnv_germ_tab}
+purple_cnv_germ$tab %>%
+  DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
+                class = "cell-border display compact",
+                rownames = FALSE, extensions = c("Scroller", "Buttons", "KeyTable"),
+                options = list(scroller = TRUE, scrollY = 400, scrollX = TRUE, autoWidth = TRUE, keys = TRUE,
+                               buttons = c('csv', 'excel'), dom = 'Bfrtip')) %>%
+  DT::formatCurrency(~ Start + End, currency = "", interval = 3, mark = ",", digits = 0)
+```
+
 
 ### PURPLE Charts {.tabset .tabset-fade #purple-charts}
 PURPLE generates charts for summarising tumor sample characteristics.
@@ -1811,15 +1408,10 @@ knitr::include_graphics(c(file.path(img_dir, paste0(params$batch_name, '.copynum
 
 #### Rainfall
 If a somatic variant VCF has been supplied, a figure will be produced
-showing the somatic variant ploidy broken down by copy number as well
-as a rainfall plot with kataegis clusters highlighted in grey.
+showing the somatic variant ploidy broken down by copy number.
 
 ```{r purple_plot_somatic, out.width="40%"}
 knitr::include_graphics(file.path(img_dir, paste0(params$batch_name, '.somatic.png')))
-```
-
-```{r purple_plot_somaticrainfall, out.width="90%"}
-knitr::include_graphics(file.path(img_dir, paste0(params$batch_name, '.somatic.rainfall.png')))
 ```
 
 #### Purity/ploidy
@@ -1924,7 +1516,7 @@ conda_pkgs %>%
   dplyr::filter(grepl(main_pkgs, name)) %>%
   dplyr::arrange(desc(name)) %>%
   knitr::kable(format = "html") %>%
-  kableExtra::kable_styling(full_width = TRUE, position = "left") %>%
+  kableExtra::kable_paper(c("hover", "striped"), full_width = TRUE, position = "left") %>%
   kableExtra::column_spec(1, bold = TRUE) %>%
   kableExtra::scroll_box(height = "300px")
 ```
@@ -1932,9 +1524,12 @@ conda_pkgs %>%
 ### Report Inputs
 
 ```{r report_inputs}
-dplyr::tibble(key = names(params), value = unlist(params)) %>%
+report_inputs <- dplyr::tibble(key = names(params), value = unlist(params))
+readr::write_tsv(report_inputs, file.path(result_outdir, "report_inputs.tsv"))
+
+report_inputs %>%
   knitr::kable(format = "html") %>%
-  kableExtra::kable_styling(full_width = FALSE, position = "left") %>%
+  kableExtra::kable_paper(c("hover", "striped"), full_width = FALSE, position = "left") %>%
   kableExtra::column_spec(1, bold = TRUE) %>%
   kableExtra::scroll_box(height = "200px")
 ```

--- a/umccrise/rmd_files/cancer_report.Rmd
+++ b/umccrise/rmd_files/cancer_report.Rmd
@@ -119,6 +119,7 @@ library(htmltools)
 library(jsonlite)
 library(knitr)
 library(kableExtra)
+library(patchwork)
 library(purrr)
 library(readr)
 library(rmarkdown)
@@ -753,6 +754,7 @@ if (will_work) {
 }
 ```
 
+### Kataegis
 Somatic variants of type C>T and C>G in a TpCpN context are annotated as
 showing Kataegis (Nik Zainal et al., 2012) if there are three or more
 mutations of that type, strand and context localised within a
@@ -761,14 +763,18 @@ The annotation describes the strand it was found on
 along with an ID that is shared by grouped variants.
 
 ```{r purple_kataegis_table}
-gpgr::purple_kataegis(params$purple_som_snv_vcf) %>%
-  knitr::kable(escape = FALSE, caption = "Kataegis Regions.",
+kat <- gpgr::purple_kataegis(params$purple_som_snv_vcf)
+if (nrow(kat) > 0) {
+  knitr::kable(kat, escape = FALSE, caption = "Kataegis Regions.",
                format = "html", format.args = list(big.mark = ",")) %>%
-  kableExtra::kable_minimal("hover", full_width = FALSE, position = "left") %>%
-  kableExtra::scroll_box(height = "250px")
+    kableExtra::kable_minimal("hover", full_width = FALSE, position = "left") %>%
+    kableExtra::scroll_box(height = "150px")
+} else {
+  cat("No kataegis regions detected.")
+}
 ```
 
-```{r purple_plot_somaticrainfall, out.width="80%"}
+```{r purple_plot_somaticrainfall, out.width="70%"}
 knitr::include_graphics(file.path(img_dir, paste0(params$batch_name, '.somatic.rainfall.png')))
 ```
 
@@ -777,7 +783,6 @@ blank_lines(1)
 ```
 
 ## HRD (Homologous Recombination Deficiency) Detection {#hrd}
-
 
 <details>
 <summary>Description</summary>
@@ -1038,13 +1043,11 @@ gpgr::EFFECT_ABBREVIATIONS %>%
 
 ### Summary
 
-```{r plot_bnd_sr_pr_tot_lines, fig.width=10, fig.height=6}
+```{r plot_bnd_sr_pr_tot_lines, fig.width=12, fig.height=6, out.width="90%"}
 p1 <- gpgr:::plot_bnd_sr_pr_tot_lines(sv_unmelted)
-p2 <- gpgr::plot_bnd_sr_pr_tot_hist(sv_unmelted)
-p1
-p2
+p2 <- gpgr::plot_bnd_sr_pr_tot_hist(sv_unmelted) + ggplot2::theme(legend.position = "none")
+(p1 | p2) + patchwork::plot_layout(widths = c(3, 2))
 ```
-
 
 ```{r sv_summary, eval=!no_sv_found}
 d <-
@@ -1101,7 +1104,6 @@ svtab_rawdt <- svtab_raw %>%
                   scroller = TRUE, scrollY = 400, scrollX = TRUE, autoWidth = FALSE, keys = TRUE,
                   buttons = c('csv'), dom = 'Blfrtip'))
 ```
-
 
 ```{r svtab_raw_details, eval=!no_sv_found}
 details::details(sv_detail_table(svtab_raw))
@@ -1408,6 +1410,18 @@ blank_lines(2)
 PURPLE generates charts for summarising tumor sample characteristics.
 Description is from the [PURPLE docs](https://github.com/hartwigmedical/hmftools/tree/master/purity-ploidy-estimator#charts).
 
+#### Purity/ploidy
+The following 'sunrise' chart shows the range of scores of all examined solutions of
+purity and ploidy. Crosshairs identify the best purity / ploidy solution.
+
+```{r purple_plot_purityrange, out.width="40%"}
+knitr::include_graphics(file.path(img_dir, paste0(params$batch_name, '.purity.range.png')))
+```
+
+```{r, results='asis'}
+blank_lines(2)
+```
+
 #### Copy number / Minor allele ploidy
 The following figures show the AMBER BAF count weighted distribution of
 copy number and minor allele ploidy throughout the fitted segments.
@@ -1420,24 +1434,12 @@ knitr::include_graphics(c(file.path(img_dir, paste0(params$batch_name, '.copynum
                         file.path(img_dir, paste0(params$batch_name, '.map.png'))))
 ```
 
-```{r, results='asis'}
-blank_lines(2)
-```
-
 #### Rainfall
 If a somatic variant VCF has been supplied, a figure will be produced
 showing the somatic variant ploidy broken down by copy number.
 
 ```{r purple_plot_somatic, out.width="40%"}
 knitr::include_graphics(file.path(img_dir, paste0(params$batch_name, '.somatic.png')))
-```
-
-#### Purity/ploidy
-The following 'sunrise' chart shows the range of scores of all examined solutions of
-purity and ploidy. Crosshairs identify the best purity / ploidy solution.
-
-```{r purple_plot_purityrange, out.width="40%"}
-knitr::include_graphics(file.path(img_dir, paste0(params$batch_name, '.purity.range.png')))
 ```
 
 #### Clonality
@@ -1489,9 +1491,11 @@ if (!is.na(breakpoints_tsv) && breakpoints_tsv != "" && file.exists(breakpoints_
     DT::formatCurrency(~ Coord, currency = "", interval = 3, mark = ",", digits = 0)
 } else {
   if (!is.na(present_viruses) && present_viruses != "" && file.exists(present_viruses)) {
-    viruses = readr::read_file(present_viruses)
+    viruses <- readr::read_file(present_viruses)
     if (str_length(viruses) > 0) {
-      cat(str_c("Deteced significant traces of content of the following viruses: ", viruses, ", however no evidence of viral integration into the host genome is observed."))
+      cat(str_c("Detected significant traces of content of the following viruses: ",
+                viruses,
+                ", however no evidence of viral integration into the host genome is observed."))
     } else {
       cat("No oncoviral content detected in this sample.")
     }
@@ -1499,7 +1503,6 @@ if (!is.na(breakpoints_tsv) && breakpoints_tsv != "" && file.exists(breakpoints_
     cat("Oncoviral detection was disabled in the umccrise run with `-E oncoviruses`.")
   }
 }
-
 ```
 
 ```{r, results='asis'}
@@ -1513,9 +1516,10 @@ blank_lines(1)
 ### Conda Pkgs Main
 
 ```{r conda_list_main}
-conda_pkgs <- readr::read_table2(params$conda_list,
-                                 col_names = c("env", "name", "version", "build", "channel"),
-                                 col_types = "ccccc") %>%
+conda_pkgs <-
+  readr::read_table2(params$conda_list,
+                     col_names = c("env", "name", "version", "build", "channel"),
+                     col_types = "ccccc") %>%
   dplyr::mutate(channel = ifelse(is.na(channel), "MISSING", channel),
                 env = sub("env", "umccrise", env),
                 env = sub("^umccrise_", "", env)) %>%
@@ -1524,19 +1528,16 @@ conda_pkgs <- readr::read_table2(params$conda_list,
   dplyr::summarise(envs = paste(env, collapse = ", "), .groups = "drop_last") %>%
   dplyr::ungroup()
 
-
-main_pkgs <- c(
-  "^cacao", "^conpair$", "^cpsr",
-  "^gridss", "^hmftools", "^reference", "^htslib$",
-  "^multiqc", "^ngs",
-  "pandoc", "^pcgr", "^python$",
-  "^r-base$", "snakemake",
-  "^umccrise$") %>%
-  paste(collapse = "|")
-
-conda_pkgs %>%
-  dplyr::filter(grepl(main_pkgs, name)) %>%
-  dplyr::arrange(desc(name)) %>%
+# main pkgs
+tibble::tibble(
+  name = c(
+    "umccrise", "r-gpgr", "r-base", "pcgr", "cpsr", "cacao",
+    "hmftools-purple", "hmftools-amber", "hmftools-cobalt", "hmftools-sage",
+    "multiqc", "multiqc-bcbio", "reference-data",
+    "samtools", "bcftools", "htslib", "ngs_utils", "python", "pandoc"
+  )
+) %>%
+  dplyr::left_join(conda_pkgs, by = "name") %>%
   knitr::kable(format = "html") %>%
   kableExtra::kable_paper(c("hover", "striped"), full_width = TRUE, position = "left") %>%
   kableExtra::column_spec(1, bold = TRUE) %>%
@@ -1565,25 +1566,3 @@ conda_pkgs %>%
                 options = list(scroller = TRUE, scrollX = TRUE, scrollY = 400,
                                buttons = c('csv'), dom = 'Bfrtip'))
 ```
-
-```{r session_info, eval=F}
-si <- devtools::session_info(include_base = TRUE)
-si_pl <- unclass(si$platform) %>% as_tibble() %>% t()
-# si_pkg <- unclass(si$packages) %>%
-#   dplyr::as_tibble() %>%
-#   dplyr::select(package, version = ondiskversion, path, datestamp = date)
-
-dplyr::tibble(var = row.names(si_pl),
-              value = si_pl[, , drop = TRUE]) %>%
-  knitr::kable(format = "html") %>%
-  kableExtra::kable_styling(full_width = FALSE, position = "left") %>%
-  kableExtra::column_spec(1, bold = TRUE)
-```
-
-```{r session_info_pkgs, eval=F}
-knitr::kable(si_pkg, format = "html") %>%
-  kableExtra::kable_styling(full_width = TRUE, position = "left") %>%
-  kableExtra::column_spec(1, bold = TRUE) %>%
-  kableExtra::scroll_box(height = "400px")
-```
-

--- a/umccrise/rmd_files/cancer_report.Rmd
+++ b/umccrise/rmd_files/cancer_report.Rmd
@@ -131,17 +131,7 @@ library(gpgr)
 ```{r funcs}
 img_dir <- file.path("img") # created when copying purple files to tmp dir
 result_outdir <- params$result_outdir # directory to write tables to
-
-# for checking if the columns in the dt are all described
-check_cols_described <- function(cols, descr) {
-  stopifnot(is.character(cols), is.atomic(cols))
-  stopifnot(is.character(descr), is.atomic(descr))
-  for (col in cols) {
-    if (!col %in% descr) {
-      warning(glue::glue("{col} is not described!"))
-    }
-  }
-}
+blank_lines <- function(n = 10){cat(rep("&nbsp;  ",n), sep="\n")}
 
 # get js indices when using in DT options
 col_ind_js <- function(dt, col) {
@@ -152,72 +142,24 @@ col_ind_js <- function(dt, col) {
 
 # used in SV table Details
 sv_detail_table <- function(tab) {
+  # for checking if the columns in the dt are all described
+  check_cols_described <- function(cols, descr) {
+    stopifnot(is.character(cols), is.atomic(cols))
+    stopifnot(is.character(descr), is.atomic(descr))
+    for (col in cols) {
+      if (!col %in% descr) {
+        warning(glue::glue("{col} is not described!"))
+      }
+    }
+  }
+
   check_cols_described(colnames(tab), sv_col_descr$Column)
   list(Column = colnames(tab)) %>%
     tibble::as_tibble() %>%
     dplyr::left_join(sv_col_descr, by = "Column")
 }
-
-mkdir <- function(d) {
-  if (!dir.exists(d)) {
-    dir.create(d, recursive = TRUE)
-  }
-}
-
-write_tsvgz <- function(x, path, ...) {
-  assertthat::assert_that(endsWith(path, ".gz"))
-  tsv_path <- file.path(result_outdir, path)
-  mkdir(dirname(tsv_path))
-  readr::write_tsv(x = x, file = tsv_path, ...)
-}
-
-write_jsongz <- function(x, path, ...) {
-  assertthat::assert_that(endsWith(path, ".gz"))
-  json_path <- file.path(result_outdir, "json",  path)
-  mkdir(dirname(json_path))
-  gz <- gzfile(json_path, open = "w")
-  jsonlite::write_json(x = x, path = gz, ...)
-  close(gz)
-}
-
-write_tsvjsongz <- function(x, path, ...) {
-  json_path <- paste0(path, ".json.gz")
-  tsv_path <- paste0(path, ".tsv.gz")
-  write_tsvgz(x, tsv_path)
-  write_jsongz(x, json_path)
-}
 ```
 
-```{r allele_freq_prep}
-#---- Allele Frequencies ----#
-set.seed(42)
-af_global <-
-  readr::read_tsv(params$af_global, col_types = "d") %>%
-  dplyr::mutate(set = "Global")
-
-af_keygenes <-
-  readr::read_tsv(params$af_keygenes, col_types = "cicccd") %>%
-  dplyr::select(af) %>%
-  dplyr::mutate(set = 'Key genes CDS')
-
-af_both <-
-  dplyr::bind_rows(af_global, af_keygenes) %>%
-  dplyr::mutate(set = factor(set, levels = c("Global", "Key genes CDS")))
-
-mode2 <- function(x) {
-  ux <- unique(x)
-  ux[which.max(tabulate(match(x, ux)))]
-}
-
-af_stats <- af_both %>%
-  dplyr::group_by(set) %>%
-  dplyr::summarise(n = n(),
-                   mean = round(mean(af), 2),
-                   median = round(median(af), 2),
-                   mode = round(mode2(af), 2),
-                   .groups = "drop_last") %>%
-  tidyr::complete(set, fill = list(n = 0))
-```
 
 ```{r hrd_prep, results='hide'}
 #---- Homologous Recombination Deficiency ----#
@@ -339,8 +281,8 @@ mut_sig_contr2 <-
   dplyr::select(Rank, Signature = sig, Contribution = contr, Freq) %>%
   dplyr::arrange(Rank)
 
-write_tsvjsongz(mut_sig_contr1, "sigs/mutsig1")
-write_tsvjsongz(mut_sig_contr2, "sigs/mutsig2")
+gpgr::write_tsvjsongz(mut_sig_contr1, "sigs/mutsig1", result_outdir)
+gpgr::write_tsvjsongz(mut_sig_contr2, "sigs/mutsig2", result_outdir)
 ```
 
 ```{r sv_prep}
@@ -371,8 +313,8 @@ if (sv_path == "NA") {
   }
 }
 
-write_tsvjsongz(sv_unmelted, "sv/01_sv_unmelted")
-write_tsvjsongz(sv_all, "sv/02_sv_melted")
+gpgr::write_tsvjsongz(sv_unmelted, "sv/01_sv_unmelted", result_outdir)
+gpgr::write_tsvjsongz(sv_all, "sv/02_sv_melted", result_outdir)
 ```
 
 ```{r purple_prep}
@@ -387,9 +329,13 @@ purple_cnv_som <- gpgr::purple_cnv_som_process(params$purple_som_cnv)
 purple_cnv_som_gene <- gpgr::purple_cnv_som_gene_process(params$purple_som_gene_cnv, params$key_genes)
 purple_cnv_germ <- gpgr::purple_cnv_germ_process(params$purple_germ_cnv)
 
-write_tsvjsongz(purple_cnv_som$tab, "purple/purple_cnv_som")
-write_tsvjsongz(purple_cnv_som_gene$tab, "purple/purple_cnv_som_gene")
-write_tsvjsongz(purple_cnv_germ$tab, "purple/purple_cnv_germ")
+gpgr::write_tsvjsongz(purple_cnv_som$tab, "purple/purple_cnv_som", result_outdir)
+gpgr::write_tsvjsongz(purple_cnv_som_gene$tab, "purple/purple_cnv_som_gene", result_outdir)
+gpgr::write_tsvjsongz(purple_cnv_germ$tab, "purple/purple_cnv_germ", result_outdir)
+```
+
+```{r, results='asis'}
+blank_lines(2)
 ```
 
 ## Summary
@@ -446,18 +392,16 @@ summarise_sigs <- function(mut_sig_contr) {
     paste(collapse = ", ")
 }
 
-hrd_summary <- list(chord = round(chord_res[["prediction"]][, "p_hrd", drop = TRUE], 3),
-                    hrdetect = round(hrdetect_res[, "Probability", drop = TRUE], 3))
+hrd_summary <- list(chord = chord_res[["prediction"]][, "p_hrd", drop = TRUE],
+                    hrdetect = hrdetect_res[, "Probability", drop = TRUE])
 
 cnv_summary <-
   list(som = purple_cnv_som$tab, germ = purple_cnv_germ$tab) %>%
-  dplyr::bind_rows(.id = "group") %>%
-  dplyr::group_by(group) %>%
-  dplyr::summarise(
+  purrr::map(~ dplyr::summarise(
+    .x,
     Min = round(min(CN), 2),
     Max = round(max(CN), 2),
-    N = dplyr::n(), .groups = "drop_last") %>%
-  base::split(.$group)
+    N = dplyr::n(), .groups = "drop_last"))
 
 if (no_sv_found) {
   sv_summary <- tibble(unmelted = c(0), melted = c(0))
@@ -527,7 +471,15 @@ qc_summary_all %>%
   gt::tab_options(table.align = "left")
 ```
 
+```{r, results='asis'}
+blank_lines(1)
+```
+
 ## Somatic Mutation Profiles
+
+```{r, results='asis'}
+blank_lines(1)
+```
 
 ### Allelic Frequencies {#allelic-freqs}
 Summarised below are the allele frequencies (AFs) for somatic variants detected
@@ -557,31 +509,21 @@ The following post-processing steps occur:
 </details>
 
 
-```{r allele_freq_plot_stats, fig.width=10, fig.height=3}
-af_stats %>%
-  gt::gt(rowname_col = "set") %>%
-  gt::tab_header(
-    title = "AF Summary Stats"
-  ) %>%
-  gt::tab_stubhead(label = "Set") %>%
-  gt::tab_style(
-    style = list(
-      cell_text(weight = "bold")
-    ),
-    locations = cells_stub(rows = TRUE)
-  ) %>%
-  gt::tab_options(table.align = "left")
+```{r allele_freq_stats}
+af_summary_results <- gpgr::af_summary(params$af_global, params$af_keygenes)
+af_summary_results$af_stats_gt
+```
 
-ggplot2::ggplot(data = af_both, ggplot2::aes(af)) +
-  ggplot2::geom_histogram(stat = 'bin', binwidth = 0.01, fill = "#008080") +
-  ggplot2::facet_wrap(~set, scales = 'free_y', drop = FALSE) +
-  ggplot2::scale_x_continuous(name = "Allele Frequency",
-                     breaks = seq(0, 1, by = 0.1),
-                     limits = c(0, 1), expand = c(0, 0)) +
-  ggplot2::theme_bw() +
-  ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 45, vjust = 1, hjust = 1),
-        panel.grid.minor = ggplot2::element_blank()) +
-  ggplot2::labs(title = "AF count distribution")
+```{r, results='asis'}
+blank_lines(1)
+```
+
+```{r allele_freq_plot, fig.width=10, fig.height=3}
+af_summary_results$af_plot
+```
+
+```{r, results='asis'}
+blank_lines(1)
 ```
 
 ### Mutational Signatures {.tabset .tabset-fade #signatures}
@@ -712,6 +654,10 @@ MutationalPatterns::plot_strand(strand_counts_rep, mode = "relative")
 MutationalPatterns::plot_strand_bias(strand_bias_rep)
 ```
 
+```{r, results='asis'}
+blank_lines(1)
+```
+
 ### Signature Contribution {.tabset .tabset-fade #contributions}
 
 <details>
@@ -730,7 +676,9 @@ and reference signature plots from <https://cancer.sanger.ac.uk/cosmic/signature
 
 </details>
 
-<p>&nbsp;</p>
+```{r, results='asis'}
+blank_lines(1)
+```
 
 #### OLD
 
@@ -747,6 +695,11 @@ mut_sig_contr1 %>%
   kableExtra::kable_styling(c("hover", "striped"), font_size = 12) %>%
   kableExtra::scroll_box(height = "400px")
 ```
+
+```{r, results='asis'}
+blank_lines(1)
+```
+
 
 #### NEW
 
@@ -768,7 +721,9 @@ mut_sig_contr2 %>%
   kableExtra::scroll_box(height = "400px")
 ```
 
-<p>&nbsp;</p>
+```{r, results='asis'}
+blank_lines(1)
+```
 
 ### Rainfall Plot {#rainfall}
 Rainfall plots show the distribution of mutations along the genome, with mutation types
@@ -809,14 +764,17 @@ along with an ID that is shared by grouped variants.
 gpgr::purple_kataegis(params$purple_som_snv_vcf) %>%
   knitr::kable(escape = FALSE, caption = "Kataegis Regions.",
                format = "html", format.args = list(big.mark = ",")) %>%
-  kableExtra::kable_paper("hover", full_width = FALSE, position = "left") %>%
+  kableExtra::kable_minimal("hover", full_width = FALSE, position = "left") %>%
   kableExtra::scroll_box(height = "250px")
 ```
 
-```{r purple_plot_somaticrainfall, out.width="90%"}
+```{r purple_plot_somaticrainfall, out.width="80%"}
 knitr::include_graphics(file.path(img_dir, paste0(params$batch_name, '.somatic.rainfall.png')))
 ```
 
+```{r, results='asis'}
+blank_lines(1)
+```
 
 ## HRD (Homologous Recombination Deficiency) Detection {#hrd}
 
@@ -869,11 +827,14 @@ that includes HRDetect.
 </details>
 
 ```{r chord_hrdetect_res}
-hrd_results <- gpgr::hrd_summary(hrdetect_res, chord_res)
-write_tsvjsongz(hrd_results$hrd_results_tab, "hrd/chord_hrdetect")
+hrd_results <- gpgr::hrd_results_tabs(hrdetect_res, chord_res)
+gpgr::write_tsvjsongz(hrd_results$hrd_results_tab, "hrd/chord_hrdetect", result_outdir)
 hrd_results$hrd_results_gt
 ```
 
+```{r, results='asis'}
+blank_lines(1)
+```
 
 ## Circos Plots {.tabset .tabset-fade #circos}
 Circos plots are generated by PURPLE.
@@ -1033,8 +994,6 @@ sv_tsv_descr %>%
   kableExtra::scroll_box(height = "250px")
 ```
 
-<p>&nbsp;</p>
-
 __Prioritisation process__
 
 1. Annotate with [SnpEff](http://snpeff.sourceforge.net/SnpEff_manual.html) based on Ensembl gene model
@@ -1077,8 +1036,6 @@ gpgr::EFFECT_ABBREVIATIONS %>%
 
 </details>
 
-<p>&nbsp;</p>
-
 ### Summary
 
 ```{r plot_bnd_sr_pr_tot_lines, fig.width=10, fig.height=6}
@@ -1089,31 +1046,44 @@ p2
 ```
 
 
-```{r sv_summary, results='asis', eval=!no_sv_found}
-sv_tier_vs_svtype <- function() {
-  l <- list(unmelted = sv_unmelted %>% dplyr::select(TierTop, Type),
-            melted = sv_all %>% dplyr::select(Tier, Type)) %>%
-    purrr::map(function(x) addmargins(table(x, useNA = 'ifany')))
+```{r sv_summary, eval=!no_sv_found}
+d <-
+  list(unmelted = sv_unmelted %>% dplyr::select(Tier = TierTop, Type),
+       melted = sv_all %>% dplyr::select(Tier, Type)) %>%
+  dplyr::bind_rows(.id = "group") %>%
+  dplyr::mutate(group = factor(group, levels = c("unmelted", "melted"))) %>%
+  dplyr::group_by(group) %>%
+  dplyr::count(Tier, Type) %>%
+  tidyr::pivot_wider(names_from = Type, values_from = n) %>%
+  dplyr::ungroup() %>%
+  dplyr::rowwise() %>%
+  dplyr::mutate(tot = sum(dplyr::c_across(!(c(group, Tier))), na.rm = TRUE))
 
-  cap_unmelt <- glue::glue("SV type by {htmltools::strong('top')} tier {htmltools::strong('before')}",
-                           "{htmltools::br()}breaking down by annotation")
-  cap_melt <- glue::glue("SV type by {htmltools::strong('individual')} tier {htmltools::strong('after')}",
-                         "{htmltools::br()}breaking down by annotation")
-  unmelted <- knitr::kable(l$unmelted, format = "html", caption = cap_unmelt, output = FALSE) %>%
-    kableExtra::kable_paper(c("hover", "striped"), full_width = FALSE, position = "float_right")
-  melted <- knitr::kable(l$melted, format = "html",
-                         caption = cap_melt, output = FALSE) %>%
-    kableExtra::kable_paper(c("hover", "striped"), full_width = FALSE, position = "float_right")
+d %>%
+  gt::gt(
+    groupname_col = "group",
+    rowname_col = "Tier") %>%
+  gt::tab_header(
+    title = "SV type counts by tier",
+    subtitle = "(TopTier used for melted variants)"
+  ) %>%
+  gt::tab_stubhead(label = "Tier") %>%
+  gt::summary_rows(groups = TRUE,
+                   fns = list(tot = ~sum(., na.rm = TRUE)),
+                   drop_trailing_zeros = TRUE) %>%
+  gt::fmt_missing(columns = dplyr::everything()) %>%
+  gt::tab_style(
+    style = list(
+      cell_text(weight = "bold")
+    ),
+    locations = cells_stub(rows = TRUE)
+  ) %>%
+  gt::cols_align("right") %>%
+  gt::tab_options(table.align = "left")
+```
 
-  list(unmelted = unmelted, melted = melted)
-}
-cat(c(
-  '<table><tr valign="top"><td>',
-  sv_tier_vs_svtype()$unmelted,
-  '</td>', '<td>',
-  sv_tier_vs_svtype()$melted,
-  '</td></tr></table>'),
-  sep = '')
+```{r, results='asis'}
+blank_lines(1)
 ```
 
 ### Unmelted Variants {#sv-unmelted}
@@ -1138,6 +1108,10 @@ details::details(sv_detail_table(svtab_raw))
 svtab_rawdt
 ```
 
+```{r, results='asis'}
+blank_lines(2)
+```
+
 ### Translocations (BNDs) {.tabset .tabset-fade #translocations}
 
 ```{r svtab_BND, eval=!no_sv_found}
@@ -1160,10 +1134,10 @@ sv_BND_purple <- sv_all %>%
   dplyr::filter(Type %in% c("PURPLE_inf")) %>%
   dplyr::select(Tier, Start, Effect, Detail, Ploidy, CN, CNC, ID)
 
-write_tsvjsongz(
+gpgr::write_tsvjsongz(
   dplyr::bind_cols(sv_BND_main, sv_BND_other %>% dplyr::select(-nrow)),
-  "sv/03_sv_BND_main")
-write_tsvjsongz(sv_BND_purple, "sv/04_sv_BND_purpleinf")
+  "sv/03_sv_BND_main", result_outdir)
+gpgr::write_tsvjsongz(sv_BND_purple, "sv/04_sv_BND_purpleinf", result_outdir)
 
 sv_BND_maindt <- sv_BND_main %>%
   DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
@@ -1196,6 +1170,10 @@ sv_BND_purpledt <- sv_BND_purple %>%
 ```{r sv_BND_main, eval=!no_sv_found}
 details::details(sv_detail_table(sv_BND_main))
 sv_BND_maindt
+```
+
+```{r, results='asis'}
+blank_lines(2)
 ```
 
 #### Other Columns
@@ -1236,27 +1214,27 @@ sv_noBND_main <- sv_noBND %>%
   dplyr::select(nrow, vcfnum, TierTop, Tier, Type, Start, End, Effect,
                 Genes, Transcript, Detail, SR_alt, PR_alt, AF_PURPLE)
 
-write_tsvjsongz(sv_noBND_main, "sv/05_sv_noBND_main")
+gpgr::write_tsvjsongz(sv_noBND_main, "sv/05_sv_noBND_main", result_outdir)
 
 sv_noBND_other <- sv_noBND %>%
   dplyr::select(vcfnum, Ploidy, AF_BPI, CNC, CN, SR_PR_ref, SScore) %>%
   dplyr::distinct()
 
-write_tsvjsongz(sv_noBND_other, "sv/06_sv_noBND_other")
+gpgr::write_tsvjsongz(sv_noBND_other, "sv/06_sv_noBND_other", result_outdir)
 
 sv_noBND_manygenes <- sv_noBND %>%
   dplyr::filter(ngen > max_genes) %>%
   dplyr::select(nrow, vcfnum, Tier, Type, Start, End,
                 Effect, ngen, Genes = Genes_original)
 
-write_tsvjsongz(sv_noBND_manygenes, "sv/07_sv_noBND_manygenes")
+gpgr::write_tsvjsongz(sv_noBND_manygenes, "sv/07_sv_noBND_manygenes", result_outdir)
 
 sv_noBND_manytx <- sv_noBND %>%
   dplyr::filter(ntrx > max_transcripts) %>%
   dplyr::select(nrow, vcfnum, Tier, Type, Start, End,
                 Effect, ntrx, Transcript = Transcript_original)
 
-write_tsvjsongz(sv_noBND_manytx, "sv/08_sv_noBND_manytranscripts")
+gpgr::write_tsvjsongz(sv_noBND_manytx, "sv/08_sv_noBND_manytranscripts", result_outdir)
 
 sv_noBND_maindt <- sv_noBND_main %>%
   DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
@@ -1305,6 +1283,10 @@ details::details(sv_detail_table(sv_noBND_main))
 sv_noBND_maindt
 ```
 
+```{r, results='asis'}
+blank_lines(2)
+```
+
 #### Other Columns
 
 ```{r sv_noBND2_other, eval=!no_sv_found}
@@ -1331,6 +1313,10 @@ The purity and ploidy estimator
 [PURPLE](https://github.com/hartwigmedical/hmftools/tree/master/purity-ploidy-estimator)
 is used to generate a copy number profile for the somatic sample.
 
+```{r, results='asis'}
+blank_lines(1)
+```
+
 ### UMCCR Gene Somatic CNV Calls {#cnv-gene}
 
 <details>
@@ -1350,8 +1336,6 @@ purple_cnv_som_gene$descr %>%
 
 </details>
 
-<p>&nbsp;</p>
-
 ```{r purple_gene_cnv_tab}
 purple_cnv_som_gene$tab %>%
   DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
@@ -1361,6 +1345,10 @@ purple_cnv_som_gene$tab %>%
                                buttons = c('csv', 'excel'), dom = 'Bfrtip')) %>%
   DT::formatCurrency(~ start + end, currency = "", interval = 3, mark = ",", digits = 0) %>%
   DT::formatRound(~ minCN + maxCN, digits = 1)
+```
+
+```{r, results='asis'}
+blank_lines(2)
 ```
 
 ### Genome-wide Somatic CNV Segments {#cnv-segs}
@@ -1386,8 +1374,6 @@ purple_cnv_som$descr %>%
 
 </details>
 
-<p>&nbsp;</p>
-
 ```{r purple_cnv_som_tab}
 purple_cnv_som$tab %>%
   DT::datatable(filter = list(position = "top", clear = FALSE, plain = TRUE),
@@ -1396,6 +1382,10 @@ purple_cnv_som$tab %>%
                 options = list(scroller = TRUE, scrollY = 400, scrollX = TRUE, autoWidth = TRUE, keys = TRUE,
                                buttons = c('csv', 'excel'), dom = 'Bfrtip')) %>%
   DT::formatCurrency(~ Start + End, currency = "", interval = 3, mark = ",", digits = 0)
+```
+
+```{r, results='asis'}
+blank_lines(2)
 ```
 
 ### Genome-wide __Germline__ CNV Segments
@@ -1410,6 +1400,9 @@ purple_cnv_germ$tab %>%
   DT::formatCurrency(~ Start + End, currency = "", interval = 3, mark = ",", digits = 0)
 ```
 
+```{r, results='asis'}
+blank_lines(2)
+```
 
 ### PURPLE Charts {.tabset .tabset-fade #purple-charts}
 PURPLE generates charts for summarising tumor sample characteristics.
@@ -1425,6 +1418,10 @@ down by copy number.
 ```{r purple_plot_copynumber, out.width="40%"}
 knitr::include_graphics(c(file.path(img_dir, paste0(params$batch_name, '.copynumber.png')),
                         file.path(img_dir, paste0(params$batch_name, '.map.png'))))
+```
+
+```{r, results='asis'}
+blank_lines(2)
 ```
 
 #### Rainfall
@@ -1505,6 +1502,10 @@ if (!is.na(breakpoints_tsv) && breakpoints_tsv != "" && file.exists(breakpoints_
 
 ```
 
+```{r, results='asis'}
+blank_lines(1)
+```
+
 ## Addendum {.tabset .tabset-fade #addendum}
 
 <a href="#top">Back to top</a>
@@ -1546,7 +1547,7 @@ conda_pkgs %>%
 
 ```{r report_inputs}
 report_inputs <- dplyr::tibble(key = names(params), value = unlist(params))
-write_tsvjsongz(report_inputs, "report_inputs")
+gpgr::write_tsvjsongz(report_inputs, "report_inputs", result_outdir)
 
 report_inputs %>%
   knitr::kable(format = "html") %>%
@@ -1585,6 +1586,4 @@ knitr::kable(si_pkg, format = "html") %>%
   kableExtra::column_spec(1, bold = TRUE) %>%
   kableExtra::scroll_box(height = "400px")
 ```
-
-<p>&nbsp;</p>
 

--- a/umccrise/rmd_files/cancer_report.Rmd
+++ b/umccrise/rmd_files/cancer_report.Rmd
@@ -193,7 +193,7 @@ af_stats <- af_both %>%
   tidyr::complete(set, fill = list(n = 0))
 ```
 
-```{r hrd_prep}
+```{r hrd_prep, results='hide'}
 #---- Homologous Recombination Deficiency ----#
 chord_sv_df <- gpgr::chord_mantavcf2df(params$somatic_sv_vcf)
 chord_res <- gpgr::chord_run(

--- a/umccrise/rmd_files/misc/circos/circos_baf.conf
+++ b/umccrise/rmd_files/misc/circos/circos_baf.conf
@@ -32,7 +32,7 @@ show_tick_labels    = no
     <<include etc/image.conf>>
 </image>
 
-karyotype = data/karyotype/karyotype.human.txt
+karyotype = data/karyotype/karyotype.human.HG_ASSEMBLY.txt
 
 chromosomes_units = 1000000
 chromosomes_display_default = yes

--- a/umccrise/rmd_files/style.css
+++ b/umccrise/rmd_files/style.css
@@ -4,13 +4,19 @@
 
 /* https://stackoverflow.com/questions/42183672/how-to-implement-a-navbar-dropdown-hover-in-bootstrap-v4/48224232#48224232 */
 .dropdown:hover > .dropdown-menu {
-    display: block;
+  display: block;
 }
 .dropdown > .dropdown-toggle:active {
-    /*Without this, clicking will make it sticky*/
-    pointer-events: none;
+  /*Without this, clicking will make it sticky*/
+  pointer-events: none;
 }
 
 table.dataTable tbody td {
   vertical-align: top;
+}
+
+.main-container {
+  max-width: 1400px !important;
+  margin-left: auto;
+  margin-right: auto;
 }

--- a/umccrise/structural.smk
+++ b/umccrise/structural.smk
@@ -1,8 +1,7 @@
 """
 Structural variants
-------------------
-Re-do the CNV plots. This will need lots of love (drop gene names, make the scatterplot viable again, etc.).
 """
+
 import glob
 from os.path import join, dirname, basename, isfile
 from cyvcf2 import VCF

--- a/umccrise/structural.smk
+++ b/umccrise/structural.smk
@@ -350,7 +350,7 @@ rule prep_sv_tsv:
             header = ["caller", "sample", "chrom", "start", "end", "svtype",
                       "split_read_support", "paired_support_PE", "paired_support_PR", "AF_BPI", "somaticscore",
                       "tier", "annotation",
-                      'AF_PURPLE', 'CN_PURPLE', 'CN_change_PURPLE', 'Ploidy_PURPLE', 'PURPLE_status', 'START_BPI', 'END_BPI', 'ID', 'MATEID']
+                      "AF_PURPLE", "CN_PURPLE", "CN_change_PURPLE", "Ploidy_PURPLE", "PURPLE_status", "START_BPI", "END_BPI", "ID", "MATEID", "ALT"]
             out.write('\t'.join(header) + '\n')
             for rec in VCF(input.vcf):
                 tier = parse_info_field(rec, 'SV_TOP_TIER')
@@ -366,7 +366,11 @@ rule prep_sv_tsv:
                 elif rec.INFO.get('RECOVERED'):
                     PURPLE_status = 'RECOVERED'
 
-                data = ['manta', sample_name, rec.CHROM, rec.POS, rec.INFO.get('END', ''),
+                data = ['manta',
+                        sample_name,
+                        rec.CHROM,
+                        rec.POS,
+                        rec.INFO.get('END', ''),
                         rec.INFO['SVTYPE'],
                         ','.join(map(str, rec.format('SR')[tumor_id])) if 'SR' in rec.FORMAT else '',
                         ','.join(map(str, rec.format('PE')[tumor_id])) if 'PE' in rec.FORMAT else '',
@@ -383,7 +387,8 @@ rule prep_sv_tsv:
                         parse_info_field(rec, 'BPI_START'),
                         parse_info_field(rec, 'BPI_END'),
                         rec.ID,
-                        parse_info_field(rec, 'MATEID')
+                        parse_info_field(rec, 'MATEID'),
+                        rec.ALT
                         ]
                 out.write('\t'.join(map(str, data)) + '\n')
 

--- a/umccrise/structural.smk
+++ b/umccrise/structural.smk
@@ -388,7 +388,7 @@ rule prep_sv_tsv:
                         parse_info_field(rec, 'BPI_END'),
                         rec.ID,
                         parse_info_field(rec, 'MATEID'),
-                        rec.ALT
+                        rec.ALT[0]
                         ]
                 out.write('\t'.join(map(str, data)) + '\n')
 


### PR DESCRIPTION
Mostly moving functionality from the Rmd to gpgr:

* `cancer_report.Rmd`:
  - change title to have sample name first (shows up in the browser tab so becomes easier to distinguish)
  - include more inputs as mentioned below
  - include kataegis regions from PURPLE (taken from reannotated PURPLE SNV VCF)
  - include SV BND plots for SR/PR counts
  - split SR/PR column into two for easier sorting for curators
  - use knitr's `eval` parameter for cleaner chunk evaluation based on presence/absence of SVs
  - move lonely css to css file
  - move AF functionality to gpgr
  - move SV functionality to gpgr
  - move PURPLE functionality to gpgr
  - use gt for summary tables
  - fix yucky HRD tables with gt
  - cnv summary includes germline calls
  - use `blank_lines()` function for nicer vertical spacing
  

* include following R pkgs in the report:
  - `details` (for writing collapsible description chunks)
  - `gt` (for tables)
  - `jsonlite` (for writing tables to json)
  - `patchwork` (for rearranging plots)

* `structural.smk`: including ALT so that we can grab the mate chromosome when it's been filtered out
* `somatic.smk`: include pierian rule, which simply renames SNV/SV/CNV files and subsets SNVs to tumor sample
* `circos_baf.conf`/`purple.smk`: this fixes a long-standing bug (which has already been fixed in PURPLE) where the hg19 karyotype was being used instead of hg38, causing SVs in telomeric regions to get dropped from our custom 'BAF' circos plot.
* `purple.smk`: rename variables, bring in germline cnvs, bring in somatic VCF for HRD
* `cancer_report.smk`: rename and add variables, most importantly `result_outdir` which is used for writing the final report tables.


