### PR TITLE
Pinned dvc version in CodeBuild build image

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,7 +13,8 @@ phases:
     commands:
       - df -h
       - apk add --no-cache python3 tree py3-pip git libxt-dev
-      - pip3 install --no-cache --upgrade pip awscli 'dvc[s3]'
+      - pip3 install --no-cache --upgrade pip
+      - pip3 install --no-cache awscli 'dvc[s3]==1.9.1'
   build:
     commands:
       # Docker-in-docker bizarre AWS stuff: https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker-custom-image.html


### PR DESCRIPTION
* Latest dvc 1.10 re-use dulwich for .gitignore
  https://github.com/iterative/dvc/pull/4809
* Regression: reintroduce issue reported in
  https://github.com/iterative/dvc/issues/2010
* Resolution: pin dvc version to 1.9.1 for now
* Build image is docker:dind Alpine Linux
