### PR TITLE
vcf2maf: ignore "Use of uninitialized value" warnings (fixes #61)

### DIFF
--- a/umccrise/somatic.smk
+++ b/umccrise/somatic.smk
@@ -284,7 +284,7 @@ rule somatic_vcf2maf:
         '--filter-vcf 0 '
         '--tumor-id {params.tname} '
         '--normal-id {params.nname} '
-        '--ncbi-build {params.ncbi_build} '
+        '--ncbi-build {params.ncbi_build} 2> >(grep -v "Use of uninitialized value" >&2)'
         '&& rm {params.uncompressed_tmp_vcf}'
 
 


### PR DESCRIPTION
Ignoring "Use of uninitialized value in list assignment" warning from vcf2maf.pl which can be generated thousands of times. Adapted from <https://stackoverflow.com/a/52575087/2169986>.

Fixes #61 