### PR TITLE
Use Ubuntu base Docker image from public ECR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM public.ecr.aws/lts/ubuntu:20.04
 MAINTAINER Vlad Saveliev "https://github.com/vladsaveliev"
 
 # Create a non-root user and group


### PR DESCRIPTION
To avoid DockerHub rate limits and to avoid hosting ourselves. Only 20.04 available, which has an LTS period ending 2025 Q1.