### PR TITLE
Fix DRAGEN file discovery and PCGR install

### DIFF
--- a/envs/docker_wrapper.yml
+++ b/envs/docker_wrapper.yml
@@ -11,5 +11,5 @@ channels:
 dependencies:
   - python >=3.7.3
   - click
-  - ngs_utils ==2.9.0
+  - ngs_utils ==2.9.1
   - nose

--- a/envs/neoantigens.yml
+++ b/envs/neoantigens.yml
@@ -10,7 +10,7 @@ channels:
 dependencies:
   - python ==3.7.3
   - versionpy ==0.4.11
-  - ngs_utils ==2.9.0
+  - ngs_utils ==2.9.1
   - vcf_stuff ==0.5.12
   - reference_data ==1.0.10
   - natsort ==7.1.0

--- a/envs/pcgr_linux.yml
+++ b/envs/pcgr_linux.yml
@@ -13,7 +13,8 @@ dependencies:
   - samtools ==1.10
   - bcftools ==1.10.2
   - click
-  - ngs_utils ==2.9.0
+  - ngs_utils ==2.9.1
   - pcgr ==0.9.0.1
   - cpsr ==0.6.0.1
   - cacao ==0.2.1.3
+  - pandoc ==2.16.1

--- a/envs/pcgr_macos.yml
+++ b/envs/pcgr_macos.yml
@@ -14,7 +14,7 @@ dependencies:
   - samtools
   - bcftools
   - click
-  - ngs_utils ==2.9.0
+  - ngs_utils ==2.9.1
   - pcgr_dockerized
   - cpsr_dockerized
   - cacao_dockerized

--- a/envs/test_ref_data.yml
+++ b/envs/test_ref_data.yml
@@ -14,7 +14,7 @@ dependencies:
   - bcftools
   - samtools
   - bedtools
-  - ngs_utils ==2.9.0
+  - ngs_utils ==2.9.1
   - natsort  # for bcbio.py in ngs_utils
   - pip:
     - "git+https://github.com/vladsaveliev/NGS_Utils#egg=ngs_utils"

--- a/envs/umccrise.yml
+++ b/envs/umccrise.yml
@@ -42,7 +42,7 @@ dependencies:
   - optitype ==1.3.5
   - peddy ==0.4.7
   - tsvtools ==0.2.0
-  - ngs_utils ==2.9.0
+  - ngs_utils ==2.9.1
   - versionpy ==0.4.11
   - bed_annotation ==1.1.6
   - natsort ==7.1.0  # for bcbio.py in ngs_utils

--- a/umccrise/__init__.py
+++ b/umccrise/__init__.py
@@ -550,6 +550,15 @@ def is_bcbio_directory(path):
     return final_dir.is_dir() and config_dir.is_dir()
 
 
+def get_dragen_output_prefix(dirpath):
+    for fp in dirpath.iterdir():
+        if not fp.match('*replay.json'):
+            continue
+        return fp.name.replace('-replay.json', '')
+    else:
+        critical('could not determine output prefix for DRAGEN directory \'{dirpath}\'')
+
+
 def create_dragen_paired_directories_from_config(smconfig):
     # Set subject identifier
     tumor_subject_id_inferred = get_subject_id_from_dragen_dir(smconfig['dragen_somatic_dir'])
@@ -602,10 +611,12 @@ def create_dragen_paired_directories_from_config(smconfig):
                 'normal': normal_id,
                 'tumor': tumor_id,
                 'path': smconfig['dragen_somatic_dir'],
+                'prefix': get_dragen_output_prefix(smconfig['dragen_somatic_dir'])
             },
             'normal_run': {
                 'normal': normal_id,
                 'path': smconfig['dragen_germline_dir'],
+                'prefix': get_dragen_output_prefix(smconfig['dragen_germline_dir'])
             },
         }
     ]
@@ -642,6 +653,7 @@ def pair_dragen_directories(paths):
         assert dir_type not in paths_sorted[sample_normal]
         paths_sorted[sample_normal][dir_type] = samples
         paths_sorted[sample_normal][dir_type]['path'] = path
+        paths_sorted[sample_normal][dir_type]['prefix'] = get_dragen_output_prefix(path)
         paths_sorted[sample_normal][dir_type]['subject_id'] = get_subject_id_from_dragen_dir(path)
 
     # Differentiated paired and unpaired paths

--- a/umccrise/multiqc.smk
+++ b/umccrise/multiqc.smk
@@ -194,7 +194,7 @@ rule prep_multiqc_data:
             generated_conf=generated_conf,
             out_filelist_file=output.filelist,
             out_conf_yaml=output.generated_conf_yaml,
-            qc_files=qc_files,
+            qc_files_input=qc_files,
             qc_files_renamed_dir=output.renamed_file_dir,
         )
 


### PR DESCRIPTION
* use DRAGEN output file prefix to locate input files rather than RGSM
* adapt QC file relabeling to fit with changes to DRAGEN file discovery
* pin pandoc to version 2.16.1 to prevent breaking PCGR