### PR TITLE
Remove bcbio test from the CodeBuild build process

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -48,7 +48,6 @@ phases:
       - git clone --depth 1 https://github.com/umccr/umccrise_test_data umccrise_test_data
       # Create output directory and set permissions for Docker container user
       - mkdir -p umccrise_test_data/results/dragen_test_project_docker/ &&
-        mkdir -p umccrise_test_data/results/bcbio_test_project_docker/ &&
         chgrp -R 1000 umccrise_test_data/results/ &&
         chmod -R g+w umccrise_test_data/results/
       # DRAGEN test run
@@ -59,14 +58,6 @@ phases:
         -v=$PWD/reference_data/genomes:/work/genomes
         $CONTAINER_REPO/$CONTAINER_NAME:$CONTAINER_VERSION
         umccrise /dragen_project -o /output_dir --genomes /work/genomes -j1
-      # bcbio test run
-      - tree -L 1 $PWD/umccrise_test_data/data/bcbio_test_project
-      - docker run -t --cpus 1
-        -v=$PWD/umccrise_test_data/results/bcbio_test_project_docker:/output_dir
-        -v=$PWD/umccrise_test_data/data/bcbio_test_project:/bcbio_project
-        -v=$PWD/reference_data/genomes:/work/genomes
-        $CONTAINER_REPO/$CONTAINER_NAME:$CONTAINER_VERSION
-        umccrise /bcbio_project -o /output_dir --genomes /work/genomes -j1
       # Push Docker image to ECR
       - $(aws ecr get-login --no-include-email --region ap-southeast-2)
       - docker push $CONTAINER_REPO/$CONTAINER_NAME:$CONTAINER_VERSION


### PR DESCRIPTION
The ICA/DRAGEN release currently has bcbio input disabled, and this PR removes the bcbio test from the CodeBuild build process.