### PR TITLE
Remove SV filter, bump BPI mem, add SNV counts

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,15 @@
-## 2.1.0 (xx Aug 2022)
+## 2.1.2rc (XX Aug 2022)
+
+[2.1.1 - 2.1.2 diff](https://github.com/umccr/umccrise/compare/2.1.1..2.1.2)
+
+- SV filter: remove SR < PR BND requirement ([issue114](https://github.com/umccr/umccrise/issues/114), [issue100](https://github.com/umccr/umccrise/issues/100), [pr115](https://github.com/umccr/umccrise/pull/115)).
+- BPI: bump memory again ([pr115](https://github.com/umccr/umccrise/pull/115), [issue88](https://github.com/umccr/umccrise/issues/88)).
+- Summarise SNV counts throughout workflow ([pr115](https://github.com/umccr/umccrise/pull/115), [issue92](https://github.com/umccr/umccrise/issues/92)).
+
+
+## 2.1.1 (15 Aug 2022)
+
+[2.0.2 - 2.1.1 diff](https://github.com/umccr/umccrise/compare/2.0.2..2.1.1)
 
 - General cleanup of codebase (remove GRIDSS, GPL wrappers, submodules, circos configs etc.).
 - PCGR:
@@ -12,6 +23,8 @@
 
 ## 2.0.2 (22 Apr 2022)
 
+[2.0.1 - 2.0.2 diff](https://github.com/umccr/umccrise/compare/2.0.1..2.0.2)
+
 - Use `FORMAT/SQ` value as `QUAL` for DRAGEN somatic variants when generating BCFtools stats
 - Update MultiQC reference data to align with above change
 - Remove DRAGEN germline fragment length histogram file from MultiQC reference set
@@ -23,9 +36,13 @@
 
 ## 2.0.1 (15 Feb 2022)
 
+[2.0.0 - 2.0.1 diff](https://github.com/umccr/umccrise/compare/2.0.0..2.0.1)
+
 - Handle multiple '@RG SM' BAM header fields ([#83](https://github.com/umccr/umccrise/pull/83))
 
 ## 2.0.0 (30 Nov 2021)
+
+[1.2.4 - 2.0.0 diff](https://github.com/umccr/umccrise/compare/1.2.4..2.0.0)
 
 - Overhaul automatic detection for DRAGEN inputs
 - Allow inputs to be provided via named arguments
@@ -43,6 +60,8 @@
 
 ## 1.2.4 (18 Nov 2021)
 
+[1.2.3 - 1.2.4 diff](https://github.com/umccr/umccrise/compare/1.2.3..1.2.4)
+
 - Simplify MultiQC installation ([pr75](https://github.com/umccr/umccrise/pull/75))
     - install `MultiQC` as conda package
     - install `MultiQC_bcbio` from umccr org
@@ -57,10 +76,14 @@
 
 ## 1.2.3 (31 Aug 2021)
 
+[1.2.2 - 1.2.3 diff](https://github.com/umccr/umccrise/compare/1.2.2..1.2.3)
+
 - Update Dockerfile and install.sh to resolve Snakemake warnings regarding input filepaths containing double slashes '//'
 - Replace root user in Docker container with non-root user
 
 ## 1.2.2 (16 Aug 2021)
+
+[1.2.1 - 1.2.2 diff](https://github.com/umccr/umccrise/compare/1.2.1..1.2.2)
 
 - Update NGS\_utils to allow custom TSV input (see https://github.com/umccr/NGS_Utils/commit/07e72b4)
 - Pin version of all appropriate Conda packages
@@ -70,6 +93,8 @@
 - Update (tsvtools)[https://github.com/vladsaveliev/tsvtools] to 0.2.0; Conda package for 0.1.0 no longer exists
 
 ## 1.2.1 (16 Dec 2020)
+
+[1.1.3 - 1.2.1 diff](https://github.com/umccr/umccrise/compare/1.1.3..1.2.1)
 
 - Decrease number of predisposition genes to 78 (see https://github.com/vladsaveliev/NGS_Utils/issues/3)
   - Should see a ~60-70% decrease in CPSR variants
@@ -105,6 +130,8 @@
 
 
 ## 1.1.3 (17 Nov 2020)
+
+[1.1.2 - 1.1.3 diff](https://github.com/umccr/umccrise/compare/1.1.2..1.1.3)
 
 Mostly moving functionality from the Rmd to gpgr (https://github.com/umccr/gpgr):
 
@@ -150,14 +177,20 @@ Mostly moving functionality from the Rmd to gpgr (https://github.com/umccr/gpgr)
 
 ## 1.1.2 (9 Oct 2020)
 
-- Added [GPGR dependency](https://umccr.github.io/gpgr/) to handle R-related enhancements more efficiently
+[1.1.1 - 1.1.2 diff](https://github.com/umccr/umccrise/compare/1.1.1..1.1.2)
+
+- Added [gpgr dependency](https://umccr.github.io/gpgr/) to handle R-related enhancements more efficiently
 - Include HRD results from HRDetect and CHORD into the cancer report
 
 ## 1.1.1 (9 Oct 2020)
 
+[1.1.0 - 1.1.1 diff](https://github.com/umccr/umccrise/compare/1.1.0..1.1.1)
+
 - Update PCGR to 0.9.0, CPSR to 0.6.0. Includes cosmetic changes and database updates. CPSR counts intronic variants in the "Other variants" summary, as the number there will be high compared to the previous version, however they don't go into any TIER down the report.
 
 ## 1.1.0 (8 Oct 2020)
+
+[1.0.9 - 1.1.0 diff](https://github.com/umccr/umccrise/compare/1.0.9..1.1.0)
 
 - Use HMF PoN for annotating/filtering small variants
   (see [vcf_stuff](https://github.com/umccr/vcf_stuff) changes).
@@ -182,11 +215,15 @@ Mostly moving functionality from the Rmd to gpgr (https://github.com/umccr/gpgr)
 
 ## 1.0.9 (16 Jul 2020)
 
+[1.0.4 - 1.0.9 diff](https://github.com/umccr/umccrise/compare/1.0.4..1.0.9)
+
 - Oncoviruses: decreased the significance threshold to report candidate viruses
 - MultiQC: fix missing variant substitutions plots
-- PCGR: copy the PCGR TSV file into small_variants
+- PCGR: copy the PCGR TSV file into small\_variants
 
 ## 1.0.4 (1 Jul 2020)
+
+[1.0.0 - 1.0.4 diff](https://github.com/umccr/umccrise/compare/1.0.0..1.0.4)
 
 - Minor fixes:
     - Fix showing conda package versions
@@ -200,6 +237,8 @@ Mostly moving functionality from the Rmd to gpgr (https://github.com/umccr/gpgr)
 - Codebuild: revert back the versioned reference data
 
 ## 1.0.0 (14 Jun 2020):
+
+[0.17.12 - 1.0.0 diff](https://github.com/umccr/umccrise/compare/0.17.12..1.0.0)
 
 - Integrated [oncoviruses](https://github.com/umccr/oncoviruses). It detects oncoviral content and possible integration sites, as well as genes affected by integration. Reported viral strains in MultiQC and integration sites and affected genes in the cancer report.
 - More DRAGEN input options:

--- a/umccrise/cancer_report.smk
+++ b/umccrise/cancer_report.smk
@@ -90,6 +90,7 @@ rule run_cancer_report:
                                if (batch_by_name[wc.batch].sv_vcf and 'structural' in stages) else [],
         somatic_sv_vcf       = lambda wc: '{batch}/structural/{batch}-manta.vcf.gz'
                                if (batch_by_name[wc.batch].sv_vcf and 'structural' in stages) else [],
+        subset_stats_yaml    = 'work/{batch}/small_variants/somatic_anno/subset_highly_mutated_stats.yaml',
         purple_som_snv_vcf   = 'work/{batch}/purple/{batch}.purple.somatic.vcf.gz',
         purple_som_cnv       = 'work/{batch}/purple/{batch}.purple.cnv.somatic.tsv',
         purple_som_gene_cnv  = 'work/{batch}/purple/{batch}.purple.cnv.gene.tsv',
@@ -123,6 +124,7 @@ rule run_cancer_report:
         somatic_snv_vcf     = lambda wc, input: abspath(input.somatic_snv_vcf),
         somatic_sv_tsv      = lambda wc, input: abspath(input.somatic_sv_tsv) if input.somatic_sv_tsv else 'NA',
         somatic_sv_vcf      = lambda wc, input: abspath(input.somatic_sv_vcf) if input.somatic_sv_vcf else 'NA',
+        subset_stats_yaml   = lambda wc, input: abspath(input.subset_stats_yaml),
         purple_som_snv_vcf  = lambda wc, input: abspath(input.purple_som_snv_vcf),
         purple_som_cnv      = lambda wc, input: abspath(input.purple_som_cnv),
         purple_som_gene_cnv = lambda wc, input: abspath(input.purple_som_gene_cnv),
@@ -166,6 +168,7 @@ gpgr.R canrep \
   --somatic_snv_vcf '{params.somatic_snv_vcf}' \
   --somatic_sv_tsv '{params.somatic_sv_tsv}' \
   --somatic_sv_vcf '{params.somatic_sv_vcf}' \
+  --subset_stats_yaml '{params.subset_stats_yaml}' \
   --purple_som_gene_cnv '{params.purple_som_gene_cnv}' \
   --purple_som_cnv '{params.purple_som_cnv}' \
   --purple_germ_cnv '{params.purple_germ_cnv}' \

--- a/umccrise/cancer_report.smk
+++ b/umccrise/cancer_report.smk
@@ -116,12 +116,12 @@ rule run_cancer_report:
         key_genes            = get_key_genes(),
         af_global            = rules.afs.output[0],
         af_keygenes          = rules.afs_keygenes.output[0],
+        somatic_snv_summary  = rules.somatic_snv_summary.output.yaml,
         somatic_snv_vcf      = '{batch}/small_variants/{batch}-somatic-PASS.vcf.gz',
         somatic_sv_tsv       = lambda wc: rules.prep_sv_tsv.output[0]
                                if (batch_by_name[wc.batch].sv_vcf and 'structural' in stages) else [],
         somatic_sv_vcf       = lambda wc: '{batch}/structural/{batch}-manta.vcf.gz'
                                if (batch_by_name[wc.batch].sv_vcf and 'structural' in stages) else [],
-        subset_stats_yaml    = 'work/{batch}/small_variants/somatic_anno/subset_highly_mutated_stats.yaml',
         purple_som_snv_vcf   = 'work/{batch}/purple/{batch}.purple.somatic.vcf.gz',
         purple_som_cnv       = 'work/{batch}/purple/{batch}.purple.cnv.somatic.tsv',
         purple_som_gene_cnv  = 'work/{batch}/purple/{batch}.purple.cnv.gene.tsv',
@@ -152,10 +152,10 @@ rule run_cancer_report:
         output_file         = lambda wc, output: join(os.getcwd(), output[0]),
         af_global           = lambda wc, input: abspath(input.af_global),
         af_keygenes         = lambda wc, input: abspath(input.af_keygenes),
+        somatic_snv_summary = lambda wc, input: abspath(input.somatic_snv_summary),
         somatic_snv_vcf     = lambda wc, input: abspath(input.somatic_snv_vcf),
         somatic_sv_tsv      = lambda wc, input: abspath(input.somatic_sv_tsv) if input.somatic_sv_tsv else 'NA',
         somatic_sv_vcf      = lambda wc, input: abspath(input.somatic_sv_vcf) if input.somatic_sv_vcf else 'NA',
-        subset_stats_yaml   = lambda wc, input: abspath(input.subset_stats_yaml),
         purple_som_snv_vcf  = lambda wc, input: abspath(input.purple_som_snv_vcf),
         purple_som_cnv      = lambda wc, input: abspath(input.purple_som_cnv),
         purple_som_gene_cnv = lambda wc, input: abspath(input.purple_som_gene_cnv),
@@ -196,10 +196,10 @@ gpgr.R canrep \
   --conda_list '{params.conda_list}' \
   --img_dir '{params.img_dir_abs}' \
   --key_genes '{input.key_genes}' \
+  --somatic_snv_summary '{params.somatic_snv_summary}' \
   --somatic_snv_vcf '{params.somatic_snv_vcf}' \
   --somatic_sv_tsv '{params.somatic_sv_tsv}' \
   --somatic_sv_vcf '{params.somatic_sv_vcf}' \
-  --subset_stats_yaml '{params.subset_stats_yaml}' \
   --purple_som_gene_cnv '{params.purple_som_gene_cnv}' \
   --purple_som_cnv '{params.purple_som_cnv}' \
   --purple_germ_cnv '{params.purple_germ_cnv}' \

--- a/umccrise/structural.smk
+++ b/umccrise/structural.smk
@@ -200,10 +200,11 @@ rule sv_bpi_maybe:
         'log/structural/{batch}/{batch}-bpi_stats.txt'
     params:
         xms = 1000,
-        xmx = 30000,
+        xmx = 64000,
         tmp_dir = '{batch}/structural/maybe_bpi/tmp_dir'
     resources:
-        mem_mb = 30000
+        # allocate 64G in 2nd attempt
+        mem_mb = lambda wildcards, attempt: attempt * 32000
     run:
         if vcf_contains_field(input.vcf, 'BPI_AF', 'INFO'):
             # already BPI'ed so just copy

--- a/umccrise/structural.smk
+++ b/umccrise/structural.smk
@@ -237,7 +237,6 @@ rule filter_sv_vcf:
         print(f'Derived tumor VCF index: {tumor_id}')
         shell('''
 bcftools view -f.,PASS {input.vcf} |
-bcftools filter -e "SVTYPE == 'BND' & FORMAT/SR[{tumor_id}:1] - FORMAT/PR[{tumor_id}:1] > 0" |
 bcftools filter -e "SV_TOP_TIER > 2 & FORMAT/SR[{tumor_id}:1]<5  & FORMAT/PR[{tumor_id}:1]<5" |
 bcftools filter -e "SV_TOP_TIER > 2 & FORMAT/SR[{tumor_id}:1]<10 & FORMAT/PR[{tumor_id}:1]<10 & (BPI_AF[0] < 0.1 | BPI_AF[1] < 0.1)" |
 bcftools view -s {t_name} -Oz -o {output.vcf} && tabix -p vcf {output.vcf}

--- a/workflow.md
+++ b/workflow.md
@@ -20,12 +20,12 @@ umccrise post-processess outputs of cancer variant calling analysis pipelines
 from [Illumina DRAGEN](https://sapac.illumina.com/products/by-type/informatics-products/dragen-bio-it-platform.html)
 and generates reports for researchers and curators at UMCCR.
 
-It takes as input results from a Tumor/Normal (T/N) variant calling workflow:
+It takes as input results from the UMCCR DRAGEN Tumor/Normal and DRAGEN Germline variant calling workflows:
 
-- BAM files from both samples (DRAGEN aligner)
-- somatic small variant calls (DRAGEN caller)
-- germline small variant calls (DRAGEN caller)
-- somatic structural variant calls (DRAGEN-Manta caller)
+- BAM files from both samples
+- somatic small variant calls
+- germline small variant calls
+- somatic structural variant calls
 
 ## Small variants (SNVs/Indels) (Somatic)
 
@@ -40,16 +40,13 @@ even if the variants are of low quality.
 2. **Keep** variants that pass DRAGEN's default quality control thresholds.
 3. **Keep** variants that are in the auto/sex/mito chromosomes (1-22, X, Y, M).
 4. **Rescue** variants that are in hotspot sites according to SAGE.
-5. **Annotate** variants with info from databases/files such as GA4GH, LCR, segdup,
-   gnomAD, HMF hotspots/GIAB/PoN, ENCODE blocklist
+5. **Annotate** variants with info from databases/files.
 6. If the sample is **hypermutated** (i.e. has > 500K variants):
    - **remove** non-hotspot variants with `gnomad_AF >= 0.01`
-   - **remove** variants not overlapping coding regions (specified in a BED file) (**TODO** for next release)
-7. **Filter** variants based on certain thresholds. Main ones are (for more details view the detailed filters further down this doc):
-   - **Keep** PCGR **Tiers 1/2**, known **hotspots**
-   - **Dump** **low AF** (`TUMOR_AF < 0.1`)
-   - **Dump** with **low read support**, **high PoN count**
-   - **Dump** indels in **homopolymers**
+   - **remove** variants not overlapping gene regions (specified in a BED file)
+7. **Filter** variants based on certain thresholds, for example:
+   - **Keep** those with PCGR **Tiers 1/2**, known **hotspots**
+   - **Dump** those with **low AF** (`TUMOR_AF < 0.1`)
 
 ### Details
 
@@ -97,7 +94,7 @@ Steps are:
 5. If after removing non-hotspot GnomAD variants there are still > 500k somatic
    variants left flag the sample as highly mutated (or FFPE) and limit all calls
    to to cancer genes only (to avoid downstream R performance problems).
-6. Standardize the VCF fields: add new `INFO` fields `TUMOR_AF`, `NORMAL_AF`,
+6. Standardise the VCF fields: add new `INFO` fields `TUMOR_AF`, `NORMAL_AF`,
    `TUMOR_DP`, `NORMAL_DP`, `TUMOR_VD`, `NORMAL_VD` (for use with PCGR), and
    `AD FORMAT` field (for use with PURPLE).
 7. Run [PCGR](https://github.com/sigven/pcgr) to annotate VCF against the
@@ -187,7 +184,7 @@ The idea is to simply bring germline variants in cancer predisposition genes:
    variants and GnomAD rare variants. It also ranks variants according
    pathogenicity score by ACMG and cancer-specific criteria. When a variant is
    annotated as having multiple functional depending on a context of a gene and
-   a trascript, a higher impact events are prioritized, and if all things equal,
+   a trascript, a higher impact events are prioritised, and if all things equal,
    [APPRIS principal transcripts](http://appris.bioinfo.cnio.es/#/) are
    preferred. In any case, one event per variant is reported. Events are
    reported in 4 tiers according to their significance:
@@ -209,33 +206,17 @@ The idea is to simply bring germline variants in cancer predisposition genes:
 ## Structural variants
 
 The idea is to report gene fusions, exon deletions, high impact and LoF events
-in tumor suppressors, and prioritize events in cancer genes.
+in tumor suppressors, and prioritise events in cancer genes.
 
-1. Start with the somatic SV VCF from
-   [bcbio](https://github.com/umccr/workflows/tree/master/bcbio) called by
-   [Manta](https://github.com/illumina/manta) SV caller.
-2. Refine SVs using Hartwig
-   [break-point-inspector](https://bioconda.github.io/recipes/break-point-inspector/README.html),
-   which locally re-assembles SV loci to get more accurate breakpoint positions
-   and AF estimates.
-3. Filter low-quality calls:
-   - require split or paired reads support at least 5x,
-   - for low frequency variants (<10% at both breakpoints), require read support
-     10x,
-   - require paired reads support to be higher than split read support for BND
-     events
-4. Annotate variants impact using
-   [SnpEff](http://snpeff.sourceforge.net/SnpEff_manual.html) according to the
-   Ensembl gene model and [Sequence ontology](http://www.sequenceontology.org)
-   terminology.
-5. Subset annotations to
-   [APPRIS principal transcripts](http://appris.bioinfo.cnio.es/#/), keeping one
-   main isoform per gene.
-6. Use variants as a guidance for PURPLE CNV calling (see below). PURPLE will
-   adjust and recover breakpoints at copy number transitions, and adjust AF
-   based on copy number, purity and ploidy.
-7. Prioritize variants with
-   [simple_sv_annotation](https://github.com/vladsaveliev/simple_sv_annotation)
+1. Start with the somatic SV VCF from DRAGEN (called internally by a private
+   [Manta](https://github.com/illumina/manta) version). Keep only PASS variants.
+2. Annotate variants:
+   - with [SnpEff](https://github.com/pcingola/SnpEff).
+   - with [VEP](https://github.com/Ensembl/ensembl-vep)
+   - Use the Ensembl gene model and [Sequence ontology](http://www.sequenceontology.org) terminology.
+   - Subset annotations to [APPRIS principal transcripts](http://appris.bioinfo.cnio.es/#/), keeping one
+     main isoform per gene.
+3. Prioritise variants with <https://github.com/umccr/vcf_stuff/blob/master/scripts/prioritize_sv>.
    on a 4 tier system - 1 (high) - 2 (moderate) - 3 (low) - 4 (no interest):
    - exon loss
      - on cancer gene list (1)
@@ -263,14 +244,20 @@ in tumor suppressors, and prioritize events in cancer genes.
      - on cancer gene list (2)
      - other TS gene (3)
    - other (4)
-8. If the number of events is over 10k (e.g. FFPE), keep only tiers 1-2-3
-9. For tiers 3-4: a. require split or paired reads support of at least 5x, b.
-   for low frequency variants (<10% at both breakpoints), require read support
-   of at least 10x, c. require paired reads support to be higher than split read
-   support for BND events
-10. Unless FFPE, feed the variants into PURPLE to recover SVs from copy number
-    transitions
-11. Report tiered variants in the UMCCR cancer report.
+4. If the number of events is over 50K (e.g. FFPE), progressively remove TIER 4/3/2 SVs (in that order).
+5. Refine SVs using Hartwig's
+   [break-point-inspector](https://github.com/hartwigmedical/hmftools/tree/bpi-v1.5/break-point-inspector),
+   which locally re-assembles SV loci to get more accurate breakpoint positions
+   and AF estimates.
+6. Filter low-quality calls:
+     - keep PASS FILTER
+     - dump TIER 3/4 where `SR < 5 & PR < 5`
+     - dump TIER 3/4 where `SR < 10 & PR < 10 & (AF0 < 0.1 | AF1 < 0.1)`
+7. Use filtered variants as a guidance for PURPLE CNV calling (see below).
+   PURPLE will adjust and recover breakpoints at copy number transitions,
+   and adjust AF based on copy number, purity and ploidy.
+8. Run <https://github.com/umccr/vcf_stuff/blob/master/scripts/prioritize_sv> on the PURPLE output SVs.
+9. Report tiered variants in the UMCCR cancer report.
 
 ## Copy Number Variants
 
@@ -288,7 +275,7 @@ workflow in this step. The PURPLE pipeline outlines as follows:
   guidance),
 - Estimate the purity and copy number profile (uses somatic variants for better
   fitting),
-- Plot a circos plot that visualizes the CN/ploidy profile, as well as somatic
+- Plot a circos plot that visualises the CN/ploidy profile, as well as somatic
   variants, SVs, and BAFs,
 - Rescue structural variants in copy number transitions and filter single
   breakends,
@@ -718,7 +705,6 @@ The result is a list of 1248 genes.
 
    - Filters in sequence:
      - keep PASS FILTER
-     - dump BNDs where `SR > PR`
      - dump TIER 3/4 where `SR < 5 & PR < 5`
      - dump TIER 3/4 where `SR < 10 & PR < 10 & (AF0 < 0.1 | AF1 < 0.1)`
      - **TODO**: reorg this


### PR DESCRIPTION
This is a bit of a multi-featured PR. You could also call it a too-lazy-to-create-separate-PRs PR.

- Most importantly, we are removing the SV filter where we were discarding BNDs with SR > PR (solves #114). Curators at least are happy with this change.
- I'm also bumping the BPI memory (again - hopefully solves #88 again).
- Counting number of variants in SNV VCFs throughout the workflow and summarising in cancer report (connected to umccr/gpgr#53). Mostly useful for cases where you're wondering how the 2,000,000 original variants were filtered down to 42.