### PR TITLE
vcf2maf update

### DIFF
--- a/envs/umccrise.yml
+++ b/envs/umccrise.yml
@@ -46,7 +46,7 @@ dependencies:
   - versionpy ==0.4.11
   - bed_annotation ==1.1.6
   - natsort ==7.1.0  # for bcbio.py in ngs_utils
-  - vcf2maf ==1.6.19
+  - umccr::vcf2maf ==1.6.21.20230511
   - dvc ==1.11.6
   - dvc-s3 ==1.11.6
   - pathspec ==0.9.0

--- a/umccrise/somatic.smk
+++ b/umccrise/somatic.smk
@@ -303,10 +303,9 @@ rule somatic_vcf2maf:
         '--input-vcf {params.uncompressed_tmp_vcf} '
         '--output-maf {output.maf} '
         '--ref-fasta {input.fa} '
-        '--filter-vcf 0 '
         '--tumor-id {params.tname} '
         '--normal-id {params.nname} '
-        '--ncbi-build {params.ncbi_build} 2> >(grep -v "Use of uninitialized value" >&2)'
+        '--ncbi-build {params.ncbi_build} 2> >(grep -v "Use of uninitialized value" >&2) '
         '&& rm {params.uncompressed_tmp_vcf}'
 
 


### PR DESCRIPTION
Updated to using vcf2maf via our umccr fork ([GH](https://github.com/umccr/vcf2maf) and [conda](https://anaconda.org/umccr/vcf2maf)) since its maintenance has stopped for the past several months.
I needed to remove the `--filter-vcf 0` option since it's deprecated as of ~2 years ago; hopefully that doesn't have an impact on downstream results (I think all it does is it adds a `common_variant` tag or something).

@skanwal if you have any idea about the vcf2maf command line or would like something specified differently let me know!


-- Also, solves #133 